### PR TITLE
docs: quickstart works on externally-managed Python environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ Every published value can be recomputed from its own receipts.
 ```
 git clone https://github.com/getcomputable/gpu-index
 cd gpu-index
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 ./reproduce h100 "$(date -u +%F)"
 ```
 
-(httpx is the only runtime dependency.)
+(httpx is the only runtime dependency. The virtual environment keeps the
+install local; on systems that allow bare `pip install`, the venv lines are
+optional.)
 
 That reproduces the current UTC day: every H100 observation published so far,
 recomputed from the published per-provider receipts and matched against the


### PR DESCRIPTION
Bare `pip install -e .` fails with an externally-managed-environment refusal on modern macOS and recent Debian/Ubuntu/Fedora, so visitors following the quickstart verbatim die on line 3. Adds the two venv lines with a note that they are optional where bare pip works. Verified end-to-end tonight: fresh clone + venv + reproduce = 15/15 MATCH on all four SKUs for the current day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getcomputable/codesmith/gpu-index/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790826567&installation_model_id=433894&pr_number=35&repository=getcomputable%2Fgpu-index&return_to=https%3A%2F%2Fgithub.com%2Fgetcomputable%2Fgpu-index%2Fpull%2F35&signature=e49aba07659b85523513d835c9d9c7a83e2358c5798115fe4355420cc6bba601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->