### PR TITLE
feat: replay the serving generation — attendance weighting, and the minute-keyed lane fence scoped to publishing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,7 +17,7 @@ common  <--  observatory  <--  index  <--  published
 
 Every package may import `common`. `index` consumes the observatory's
 record and its label machinery; `published` re-derives published values
-with the index engine's own vote math. Two edges are declared waivers
+with the index engine's own vote math. Three edges are declared waivers
 rather than layering accidents:
 
 1. `observatory/sources/vast.py` imports `gpu_index.index.composite`
@@ -28,6 +28,12 @@ rather than layering accidents:
 2. `index` imports `gpu_index.observatory.catalog` (label normalization
    and the token-boundary matcher) so a token means the same thing to the
    catalog and to the panel screens.
+3. `index/panel_config.py` imports `gpu_index.observatory.collect`
+   (`VALID_FAILURE_KINDS`) so the carry-forward failure scope
+   (METHODOLOGY.md section 8.6) is validated against the ONE
+   classification vocabulary the capture lane records with — an error
+   string is not a contract, and a second copy of the kinds list would
+   drift silently.
 
 The observatory and index packages deliberately share single-home
 machinery in both directions (the catalog's label normalization feeds the

--- a/README.md
+++ b/README.md
@@ -108,8 +108,10 @@ live duplication of the observatory collectors.
 ## Architecture
 
 Four packages, layered `common <- observatory <- index <- published`, with
-two declared waiver edges (the vast collector shares the calc lane's
-order-book parser; the panel screens share the catalog's label machinery).
+three declared waiver edges (the vast collector shares the calc lane's
+order-book parser; the panel screens share the catalog's label machinery;
+the panel config validates carry-forward against the collector's failure
+vocabulary).
 The package map, the dependency arrows, the frozen-lane rationale, and the
 three contributor seams are in [ARCHITECTURE.md](ARCHITECTURE.md);
 `tests/unit/test_import_boundaries.py` enforces the arrows in CI.

--- a/scripts/compute_panel_index.py
+++ b/scripts/compute_panel_index.py
@@ -1012,22 +1012,37 @@ def main() -> int:
     if args.verify_published:
         return verify_published_observation(args, config, params, schedule)
 
-    if schedule.minute_keyed and os.environ.get(
-        "PANEL_MINUTE_LANES_LIVE"
-    ) != "true":
+    if (
+        schedule.minute_keyed
+        and not args.dry_run
+        and os.environ.get("PANEL_MINUTE_LANES_LIVE") != "true"
+    ):
         # The mechanical gate on the 15-minute mint prerequisites: a
         # minute-keyed doc passes every validator by design -- and
         # --check-config above stays fence-free so a config-only PR can
-        # validate offline -- but RUNNING one before the minute-grain
+        # validate offline -- but PUBLISHING one before the minute-grain
         # ingest and the replay-checkpoint follow-up are live would
         # dual-publish a keyspace the downstream cannot read while the
         # replay walk grows toward the per-lane cap. Loud refusal, one
         # lane (the sweeper's rc aggregation keeps the other lanes
         # running); arming is one env set, same as every lever.
+        #
+        # SCOPED TO THE PUBLISHING PATH. The hazard the fence names is
+        # DUAL-PUBLISHING, and the two read-only modes cannot commit it:
+        # --verify-published returns above (a byte-for-byte recompute
+        # that writes nothing), and --dry-run derives observations and
+        # prints them, writing nothing either. Refusing those two would
+        # fence off the one thing this repository exists for -- replaying
+        # the serving generation of a lane whose grid is minute-keyed --
+        # to protect a keyspace neither of them touches. Publishing
+        # (--sync and every persisting target) still requires the lever,
+        # unchanged and test-pinned.
         error(
-            f"{methodology_id}: minute-keyed lane refused -- set "
-            f"PANEL_MINUTE_LANES_LIVE=true only after the minute-grain "
-            f"ingest and the replay-checkpoint follow-up are live"
+            f"{methodology_id}: minute-keyed lane refused for PUBLISHING "
+            f"-- set PANEL_MINUTE_LANES_LIVE=true only after the "
+            f"minute-grain ingest and the replay-checkpoint follow-up "
+            f"are live. Read-only replay (--dry-run) and "
+            f"--verify-published are unaffected and need no lever"
         )
         return 1
 

--- a/scripts/compute_panel_index.py
+++ b/scripts/compute_panel_index.py
@@ -195,6 +195,12 @@ from gpu_index.index.composite import (  # noqa: E402
 )
 from gpu_index.index.fx import ensure_rates, load_stored_rates, rates_cover  # noqa: E402
 from gpu_index.index.panel import (  # noqa: E402
+    ATTENDANCE_KNOWN_STATUSES,
+    CARRIED_STATUS,
+    CARRY_BASIS_NO_PRICE,
+    attendance_events_for_stamp,
+    carry_prints_for,
+    carry_window_minutes,
     compile_screens,
     compute_observation,
     embedded_calc_params,
@@ -205,6 +211,7 @@ from gpu_index.index.panel import (  # noqa: E402
     record_exclusion_reason,
     record_source_for,
     resolve_member_print,
+    update_carry_book,
 )
 from gpu_index.index.panel_config import (  # noqa: E402
     PanelConfigError,
@@ -236,6 +243,7 @@ from gpu_index.index.weights import (  # noqa: E402
     MODE_DYNAMIC,
     PRUNE_MARGIN_MINUTES,
     advance_panel_weight_state,
+    attendance_minted,
     new_weight_state,
     series_print,
 )
@@ -334,6 +342,88 @@ def _next_scheduled_stamp(schedule, stamp: int) -> int:
     return upcoming[0]
 
 
+def _warn_unknown_attendance_statuses(stamp_iso: str, sources) -> None:
+    """Fail-closed visibility for the attendance classifier: a source
+    status this binary does not know -- a LATER binary's vocabulary on
+    the replay path, pure armor on the live path (compute_observation's
+    own statuses are a closed set) -- classifies as SKIP (A_i frozen, no
+    silent penalty), and the freeze must be LOUD, never a silently wrong
+    fade. ONE helper for both call sites (replay ingest + freshly
+    composed payloads); the engine module stays pure, so the log half
+    lives here."""
+    unknown = sorted(
+        {
+            str(entry.get("status"))
+            for entry in sources or []
+            if isinstance(entry, dict)
+            and entry.get("status") not in ATTENDANCE_KNOWN_STATUSES
+        }
+    )
+    if unknown:
+        warn(
+            f"{stamp_iso}: unknown source status(es) {unknown} "
+            "classified fail-closed as attendance SKIP (A_i frozen) "
+            "-- a newer binary's vocabulary; update this one"
+        )
+
+
+def _carried_warn_lines(stamp_iso: str, entry: dict, params: dict) -> list:
+    """The carried-seat log lines for one artifact row -- the basis
+    line plus, past HALF the minted carry window, the escalation whose
+    DIAGNOSIS branches on the carry basis: a failure_kind carry means
+    OUR collector is broken (fix it before the seat expires dark); a
+    no_price carry means the PROVIDER has published nothing usable
+    (there is no collector to fix -- the K_A cutoff and the carry window
+    are the relevant fences). Pure function of (row, params) so the
+    texts are unit-testable."""
+    carried = entry.get("carried") or {}
+    no_price = carried.get("carry_basis") == CARRY_BASIS_NO_PRICE
+    basis = (
+        f"carry_basis={carried.get('carry_basis')}"
+        if no_price
+        else f"failure_kind={carried.get('failure_kind')}"
+    )
+    cause = (
+        "provider produced no usable price (armed attendance)"
+        if no_price
+        else "raw entry failed collection"
+    )
+    lines = [
+        f"{stamp_iso}: {entry['source_id']} vote CARRIED from "
+        f"{carried.get('from')} "
+        f"(age {carried.get('age_minutes')}m, {basis}) -- "
+        f"{cause}; last accepted vote re-cast"
+    ]
+    # Escalation: a transient heals in one or two marks; half a window of
+    # carries needs a human.
+    age = carried.get("age_minutes")
+    window = carry_window_minutes(params)
+    if isinstance(age, (int, float)) and age > window / 2:
+        if no_price:
+            exclusion_minutes = int(
+                round(
+                    float(
+                        params["dynamic_weights"]["no_price_exclusion_hours"]
+                    )
+                    * 60.0
+                )
+            )
+            lines.append(
+                f"{stamp_iso}: {entry['source_id']} provider has produced "
+                f"no accepted print for {age}m; K_A cutoff at "
+                f"{exclusion_minutes}m / carry window {window}m"
+            )
+        else:
+            lines.append(
+                f"{stamp_iso}: {entry['source_id']} has been "
+                f"carried past HALF its minted window "
+                f"({age}m of {window}m) -- "
+                "this is no longer a transient; fix the "
+                "collector before the seat expires dark"
+            )
+    return lines
+
+
 def advance_panel_state_from_published(
     stored: dict,
     window_history: dict,
@@ -360,7 +450,17 @@ def advance_panel_state_from_published(
     the artifact's own stamp, under the artifact's own dw params -- the
     no-slot_prints replay rule: the sources[] block IS the print record,
     so nothing is ever re-derived from raw (which can legitimately grow
-    after publication)."""
+    after publication).
+
+    On a lane whose artifact params carry the minted attendance knob
+    triple (METHODOLOGY.md section 8.6), the advance also derives the
+    stamp's np/sk attendance events from the published rows via the SAME
+    classifier the live path ran
+    (gpu_index.index.panel.attendance_events_for_stamp -- the
+    classification is replay-derivable by construction, including both
+    carried flavors via carry_basis and the observation_missed /
+    record_quarantined precedence flags); knob-less artifacts advance
+    with no events and the state never grows the key."""
     artifact_params = stored.get("calc_params") or {}
     filter_terms = str(artifact_params.get("filter_terms", DEFAULT_FILTER_TERMS))
     prints: dict = {}
@@ -381,13 +481,25 @@ def advance_panel_state_from_published(
                     entry["chosen"]["usd_per_gpu_hr"], observation
                 )
     weight_calc = stored.get("weight_calc") or {}
+    dw_params = artifact_params["dynamic_weights"]
+    events = None
+    if attendance_minted(dw_params):
+        events = attendance_events_for_stamp(
+            stored.get("sources") or [],
+            observation_missed=bool(stored.get("observation_missed")),
+            record_quarantined=stored.get("record_quarantined"),
+        )
+        _warn_unknown_attendance_statuses(
+            stored["date"], stored.get("sources") or []
+        )
     advance_panel_weight_state(
         weight_state,
         obs_stamp=obs_key_to_stamp(stored["date"]),
         prints=prints,
         vector=weight_calc.get("weights"),
         mode=weight_calc.get("mode", "fallback"),
-        dw_params=artifact_params["dynamic_weights"],
+        dw_params=dw_params,
+        events=events,
     )
 
 
@@ -652,6 +764,7 @@ def verify_published_observation(args, config, params, schedule) -> int:
     window_currencies: dict = {}
     pending_currencies: dict = {}
     weight_state: dict = new_weight_state()
+    carry_book: dict = {}
     lookback = params["jump_screen"]["reference_max_lookback"]
     recent_payloads: deque = deque(maxlen=lookback)
     for prior in schedule.scheduled_stamps(schedule.genesis_stamp, target):
@@ -677,6 +790,7 @@ def verify_published_observation(args, config, params, schedule) -> int:
             pending_currencies,
             weight_state,
         )
+        update_carry_book(carry_book, prior_stored)
         recent_payloads.append(prior_stored)
 
     # The observation's snapshot: the artifact's own pinned verdict. A
@@ -745,6 +859,13 @@ def verify_published_observation(args, config, params, schedule) -> int:
         weight_state=weight_state,
         reference_prints=reference_prints,
         reference_label=reference_label,
+        # The carry book slice usable at this stamp -- None on knob-less
+        # lanes (carry_prints_for gates on the minted pair), a
+        # window-bounded slice otherwise. Byte-for-byte recompute needs
+        # the same book the live run held.
+        carry_prints=carry_prints_for(
+            carry_book, obs_stamp=target, params=params
+        ),
         schedule=schedule,
         calc_params=params,
         compiled_screens=compile_screens(params),
@@ -1091,6 +1212,15 @@ def main() -> int:
     window_currencies: dict = {}
     pending_currencies: dict = {}
     weight_state: dict = new_weight_state()
+    # Carry-forward reference book (METHODOLOGY.md section 8.6): each
+    # seat's most recent ACCEPTED print, folded from every artifact the
+    # replay walks (published verbatim or computed-this-run --
+    # byte-deterministic either way, the recent_payloads rule). A plain
+    # dict, not a deque: entries age out by the minted window at read
+    # time (carry_prints_for), so no era-dependent lookback arithmetic.
+    # Kept warm even on knob-less lanes (cheap; <= one small dict per
+    # member) so a minted flip needs no state migration.
+    carry_book: dict = {}
     # Jump-screen reference book: the trailing published/computed
     # payloads, bounded by the config's walk-back (the reference for
     # stamp t is the most recent prior non-missed artifact within
@@ -1286,6 +1416,7 @@ def main() -> int:
                 weight_state,
             )
             last_published_params = stored.get("calc_params")
+            update_carry_book(carry_book, stored)
             recent_payloads.append(stored)
             # Drift scanning is bounded in OBSERVATIONS and GATED to the
             # daily 16:00Z sweep / --drift-scan (module docstring);
@@ -1463,6 +1594,11 @@ def main() -> int:
             weight_state=weight_state,
             reference_prints=reference_prints,
             reference_label=reference_label,
+            # None on knob-less lanes (carry_prints_for gates on the
+            # minted pair), a window-bounded slice of carry_book else.
+            carry_prints=carry_prints_for(
+                carry_book, obs_stamp=stamp, params=params
+            ),
             schedule=schedule,
             # Hot-loop invariant: params/screens resolve ONCE per run
             # (compute_observation checks the methodology_id so the
@@ -1472,6 +1608,19 @@ def main() -> int:
             record_quarantined=quarantine_reason,
         )
         recent_payloads.append(payload)
+        update_carry_book(carry_book, payload)
+        if attendance_minted(params["dynamic_weights"]):
+            # Live-path twin of the replay scan: pure armor -- this
+            # binary's own statuses are a closed set.
+            _warn_unknown_attendance_statuses(stamp_iso, payload["sources"])
+        for entry in payload["sources"]:
+            if entry.get("status") == CARRIED_STATUS:
+                # Loud but not red, the quarantine posture: the basis is
+                # artifact data (vote_basis + the seat's carried block),
+                # and the seat re-observes whenever its collector heals
+                # (state-3) or the provider prints again (no_price).
+                for line in _carried_warn_lines(stamp_iso, entry, params):
+                    warn(line)
 
         weight_calc = payload.get("weight_calc") or {}
         if weight_calc.get("switched_on"):

--- a/src/gpu_index/common/slots.py
+++ b/src/gpu_index/common/slots.py
@@ -2,20 +2,30 @@
 # Copyright 2026 Computable
 """Slot gating: which capture slot a run belongs to, and idempotency.
 
-The capture job fires every 30 minutes (dozens of runs a day) but must
-record only the configured 2-4 slots. A run
-claims the LATEST slot mark at or before now (wrapping to the previous
-day's last slot), then skips itself if any snapshot already exists for
-that (date, slot) — so the first firing after each slot mark does the
-capture, every later firing in the window is a cheap no-op, and a
-scheduler dying for one firing self-heals on the next. A slot with no
-firing at all before the NEXT mark stays visibly missing — there is no
-backfill across marks. Fills recorded after the mark hour but inside the
-window carry ``late_fill: true`` in the snapshot, so what "the 16:00 UTC
-print" means (and any staleness rule for a multi-hour-late fill) is the
-composite reader's call, made on honest data — the methodology's
-promote-nearest rule (canonical-slot substitution) also belongs there, not
-in the capture path.
+The capture job fires more often than its configured slot marks (dozens
+of firings a day at the sparse basket cadence; a claim + self-heal pair
+per mark at the 15-minute observatory cadence). A run claims the LATEST
+slot mark at or before now (wrapping to the previous day's last slot),
+then skips itself if any snapshot already exists for that (date, slot)
+— so the first firing after each slot mark does the capture, every
+later firing in the window is a cheap no-op, and a scheduler dying for
+one firing self-heals on the next. A slot with no firing at all before
+the NEXT mark stays visibly missing — there is no backfill across
+marks. Fills recorded after the mark's own wall-clock window but inside
+the claim window carry ``late_fill: true`` in the snapshot, so what
+"the 16:00 UTC print" means (and any staleness rule for a late fill) is
+the composite reader's call, made on honest data — the methodology's
+promote-nearest rule (canonical-slot substitution) also belongs there,
+not in the capture path.
+
+SLOT IDENTITY: a slot is a MINUTE-OF-DAY mark (0..1439); the legacy hour
+vocabulary normalizes to its :00 minute (h*60). The KEY TOKEN format
+follows the lane's config vocabulary, pinned for the keyspace's whole
+life per writer generation: hour-vocabulary configs write the legacy
+``slot<HH>-`` token, minute-vocabulary configs write ``slot<HHMM>-`` for
+EVERY mark (":00" included) — the readers (gpu_index.common.store)
+normalize both to minute-of-day, so both token eras of one keyspace stay
+readable forever. The live lanes are minute-keyed from 2026-08-29.
 """
 
 from __future__ import annotations

--- a/src/gpu_index/index/panel.py
+++ b/src/gpu_index/index/panel.py
@@ -49,6 +49,34 @@ What is panel-NEW, each a design-doc rule:
     (gpu_index.index.weights.compute_panel_weights: per-observation R-cutoff on the
     era grid, A2 attendance floor, hour-stamped vectors), advanced with
     each observation's own trusted prints AFTER the vector is computed;
+  - CARRY-FORWARD (METHODOLOGY.md section 8.6, conditional knob pair
+    carry_forward_window_hours + carry_forward_failure_kinds): a member
+    whose raw capture entry failed collection in a minted failure class
+    re-casts its last accepted vote -- price, band, and weight verbatim
+    from the carried-from artifact -- as status ``carried``. A carried
+    seat enters ONLY the vote set: not the filter window, not the weight
+    series, not the warm-up mean, and never the claim floor; the
+    composite gains a ``vote_basis`` {observed, carried} disclosure.
+    Absent knob = the seat drops and the panel reweights over the hole,
+    byte-identically;
+  - ATTENDANCE WEIGHTING (METHODOLOGY.md sections 8.6-8.7, minted knob
+    triple attendance_half_life_hours + attendance_eta +
+    no_price_exclusion_hours, conditional like iqm_alpha): every
+    scheduled observation classifies each seat three ways
+    (attendance_events_for_stamp -- usable print / read-fine-no-price /
+    our-failure skip) and publishes a per-source EWMA attendance factor,
+    no-price streak, and exclusion flag over ALL members
+    (gpu_index.index.weights.compute_attendance_view /
+    compute_panel_weights). While DARK (eta = 0) that is all: allocation,
+    eligibility, carry, and composite are byte-identical to the
+    knob-less lane. ARMED (eta > 0, one lever): quiet seats carry their
+    booked vote through the four state-2 exit sites below (carry_basis
+    "no_price") under a CURRENT fading weight row (rule D4), the softmax
+    tilts by eta*ln(A_i) with attendance-scaled ceilings and collapsing
+    floors (rules D6/D7), and a seat past the hard cutoff of consecutive
+    no-price hours is excluded until it prints again. Knobs absent =
+    every byte identical to the pre-attendance engine (the D2 dark
+    contract, golden-pinned);
   - the artifact is per OBSERVATION: kind ``index_panel_composite``,
     ``date`` = the fixed-width YYYY-MM-DDTHH stamp (lexicographic ==
     chronological, so the store's no-regress pointer works unchanged),
@@ -82,6 +110,7 @@ out exactly one.
 
 from __future__ import annotations
 
+import copy
 import math
 import statistics
 from typing import Any, Dict, List, Optional, Sequence, Tuple
@@ -113,7 +142,11 @@ from gpu_index.index.fx import (
     FxUnavailableError,
     eur_to_usd,
 )
-from gpu_index.index.panel_schedule import stamp_to_date_minute, stamp_to_obs_key
+from gpu_index.index.panel_schedule import (
+    obs_key_to_stamp,
+    stamp_to_date_minute,
+    stamp_to_obs_key,
+)
 
 # Pinned public re-exports (tests/unit/test_public_api.py): the
 # minute re-base stopped using stamp_to_date_hour/stamp_to_hour_iso here, but downstream
@@ -124,7 +157,12 @@ from gpu_index.index.panel_schedule import (  # noqa: F401
 )
 from gpu_index.index.weights import (
     DEFAULT_TARGET_VARIANCE_FLOOR,
+    EVENT_NO_PRICE,
+    EVENT_SKIP,
     advance_panel_weight_state,
+    attendance_armed,
+    attendance_minted,
+    compute_attendance_view,
     compute_panel_weights,
     dw_vote_tail,  # re-exported: the vote-tail seam lives with the series
     series_print,
@@ -143,6 +181,25 @@ from gpu_index.observatory.catalog import boundary_pattern, normalize_label
 
 PANEL_SCHEMA_VERSION = 1
 PANEL_COMPOSITE_KIND = "index_panel_composite"
+
+# Carry-forward status (METHODOLOGY.md section 8.6): a seat re-casting a
+# booked vote is NOT "ok" -- an "ok" seat means the provider was read and
+# priced at THIS observation, and every downstream reader (drift scan,
+# jump-reference book, replay ingest) leans on that. A carried row
+# carries ``chosen`` but no ``filter`` verdict, so it advances neither
+# the outlier window nor the weight series: a stale price is a held
+# vote, never a print. The window is calc.carry_forward_window_hours.
+CARRIED_STATUS = "carried"
+
+# Carried-block basis discriminator (METHODOLOGY.md section 8.6): an
+# ARMED state-2 carry (provider read fine, no usable price -- the
+# ok-no-chosen / held_out / uncorroborated_jump / untrusted_currency
+# shapes, rule D5) publishes carry_basis "no_price" in its carried
+# block, where a collection-failure carry publishes its failure_kind.
+# The basis is the REPLAY discriminator: the attendance classifier
+# decides state-2 (A_i counts 0, streak advances) vs state-3 (our
+# failure: skip, streak holds) from this one published byte.
+CARRY_BASIS_NO_PRICE = "no_price"
 
 # Vote-sigma source (founder ruling 2026-08-27): WHICH per-source history a
 # passing print's vote stddev is computed over. "filter_window" is the
@@ -668,6 +725,25 @@ def panel_calc_params(config: Dict[str, Any]) -> Dict[str, Any]:
             if "vote_sigma_floor_pct" in calc
             else {}
         ),
+        # Carry-forward (METHODOLOGY.md section 8.6): CONDITIONAL pair
+        # like iqm_alpha -- absent means a failed seat drops and the
+        # panel reweights over the hole (every already-published
+        # artifact's bytes stay untouched; the D2 fence owns the flip, so
+        # the knob ships as a minted successor, never an edit). Load
+        # validation guarantees both-or-neither and the kinds vocabulary;
+        # sorted for canonical bytes.
+        **(
+            {
+                "carry_forward_window_hours": float(
+                    calc["carry_forward_window_hours"]
+                ),
+                "carry_forward_failure_kinds": sorted(
+                    str(k) for k in calc["carry_forward_failure_kinds"]
+                ),
+            }
+            if "carry_forward_window_hours" in calc
+            else {}
+        ),
         "manual_verify_pct": float(
             calc.get("manual_verify_pct", DEFAULT_MANUAL_VERIFY_PCT)
         ),
@@ -727,6 +803,26 @@ def panel_calc_params(config: Dict[str, Any]) -> Dict[str, Any]:
             # any other -- it rides the artifact so the switch decision
             # replays from published bytes alone.
             "attendance_floor": float(dw["attendance_floor"]),
+            # Attendance-weighting knob triple (METHODOLOGY.md section
+            # 8.6): CONDITIONAL like iqm_alpha -- keys absent means the
+            # attendance-free legacy engine byte-identically (the D2 dark
+            # contract: knob-less lanes must never grow bytes); present
+            # (all three together, load-validated) means the minted lane,
+            # eta = 0 the dark posture. Presence keyed on ONE member of
+            # the triple because validation refuses partial sets.
+            **(
+                {
+                    "attendance_half_life_hours": float(
+                        dw["attendance_half_life_hours"]
+                    ),
+                    "attendance_eta": float(dw["attendance_eta"]),
+                    "no_price_exclusion_hours": float(
+                        dw["no_price_exclusion_hours"]
+                    ),
+                }
+                if attendance_minted(dw)
+                else {}
+            ),
             "fallback_weights": {
                 m["source_id"]: m["weight"] for m in member_params
             },
@@ -1158,6 +1254,237 @@ def jump_reference_prints(
     return out
 
 
+def update_carry_book(
+    carry_book: Dict[str, Dict[str, Any]],
+    payload: Dict[str, Any],
+) -> None:
+    """Fold one panel artifact (published or computed-this-run) into the
+    caller's carry book: {source_id: the seat's most recent ACCEPTED
+    print}, the carry-forward reference (METHODOLOGY.md section 8.6).
+
+    Admission is deliberately narrower than jump_reference_prints' ok-only
+    rule: a carried seat re-casts a full prior VOTE, so only a seat that
+    actually voted may serve -- status "ok", chosen with a finite USD
+    price, filter verdict accepted, finite weight, and (when the artifact
+    carries one) a vote block with a finite band. A sigma-fenced print
+    (status ok, accepted false) never enters: the fence held it out of
+    the index, and carrying it would re-admit exactly the value the fence
+    refused. A "carried" seat never enters either -- carry never chains,
+    so a seat is only ever carried from a print somebody OBSERVED, and
+    the window measures from that observation.
+
+    Values are DEEP-copied (chosen can hold nested mutables --
+    fx_errors_partial, statistic sub-blocks): a book entry is later
+    embedded verbatim in a new artifact, and the source payload, the
+    book, and every artifact embedding from it must never share a
+    mutable object -- a future annotation pass on any nested value
+    would otherwise silently poison an already-appended payload.
+
+    panel_dark hours DO feed the book (deliberate): a below-floor hour's
+    accepted votes are real observed accepted prints -- the floor gates
+    the PUBLICATION, not the observation -- so the carry reference is the
+    seat's last accepted vote whether or not its hour printed an index
+    value."""
+    stamp = obs_key_to_stamp(str(payload["date"]))
+    for detail in payload.get("sources") or []:
+        if not isinstance(detail, dict) or detail.get("status") != "ok":
+            continue
+        chosen = detail.get("chosen")
+        verdict = detail.get("filter") or {}
+        weight = detail.get("weight")
+        if (
+            not isinstance(chosen, dict)
+            or not _finite_number(chosen.get("usd_per_gpu_hr"))
+            or float(chosen["usd_per_gpu_hr"]) <= 0
+            or verdict.get("accepted") is not True
+            or not _finite_number(weight)
+            or float(weight) <= 0
+        ):
+            # Positivity mirrors the jump screen's ref_native <= 0
+            # refusal: a zero weight would re-cast a mute vote, a
+            # negative one corrupts the renormalization denominator --
+            # fail closed against degenerate archived prints.
+            #
+            # RULED CONSEQUENCE: a K_A-excluded seat's fresh accepted
+            # RECOVERY print publishes with weight None (no weight row
+            # while excluded), so it lands here and does NOT refresh the
+            # book. If the seat re-quiets, the next armed carry re-casts
+            # the OLDER pre-exclusion booked price -- conservative, and
+            # still age-fenced by the carry window. Test-pinned.
+            continue
+        vote = detail.get("vote")
+        if vote is not None and not (
+            isinstance(vote, dict)
+            and _finite_number(vote.get("conf_usd_gpu_hr"))
+            and float(vote["conf_usd_gpu_hr"]) >= 0
+        ):
+            continue
+        carry_book[str(detail["source_id"])] = {
+            "stamp": stamp,
+            "stamp_iso": str(payload["date"]),
+            "chosen": copy.deepcopy(chosen),
+            "vote": copy.deepcopy(vote) if vote is not None else None,
+            "weight": float(weight),
+        }
+
+
+def carry_prints_for(
+    carry_book: Dict[str, Dict[str, Any]],
+    *,
+    obs_stamp: int,
+    params: Dict[str, Any],
+) -> Optional[Dict[str, Dict[str, Any]]]:
+    """The slice of the carry book usable at ``obs_stamp`` under this
+    lane's minted window, or None when the lane carries no knob (the
+    engine's carry branch is doubly gated: no knob in params, no branch).
+    Age is lattice minutes -- strictly positive (a book can never serve
+    its own stamp; the caller folds an artifact in only after compose)
+    and bounded by carry_forward_window_hours."""
+    kinds = params.get("carry_forward_failure_kinds")
+    if not kinds:
+        return None
+    window_minutes = carry_window_minutes(params)
+    return {
+        source_id: entry
+        for source_id, entry in carry_book.items()
+        if 0 < int(obs_stamp) - int(entry["stamp"]) <= window_minutes
+    }
+
+
+def carry_window_minutes(params: Dict[str, Any]) -> int:
+    """The minted carry window on the lattice: whole MINUTES (stamps are
+    minutes, so the boundary must be integer arithmetic -- a float
+    product like 0.7h * 60 = 41.999999... would expire a seat one lattice
+    step off the operator's mental model). int(round()) snaps a
+    fractional-hour mint to its nearest minute, deterministically. ONE
+    home shared by carry_prints_for and the engine's defense-in-depth
+    re-check, so the two bounds can never drift."""
+    return int(round(float(params["carry_forward_window_hours"]) * 60.0))
+
+
+# ------------------------------------- attendance classification
+#
+# ONE classifier for the live path (compute_observation classifies the
+# sources block it just built) and replay (the CLI's
+# advance_panel_state_from_published classifies the published rows), so
+# the two can never drift -- every verdict below is decided by published
+# artifact bytes alone (top-level flags, per-source status, carried-block
+# basis, filter verdict). Parity is additionally test-pinned.
+
+# State-2-with-entry statuses beyond the ok-shaped rows: the provider was
+# READ FINE and produced nothing usable (held_out = thin_book /
+# no_population_accounting; uncorroborated_jump = the L5 quarantine).
+_ATTENDANCE_NO_PRICE_STATUSES = ("held_out", QUARANTINE_REASON)
+
+# State-3 our-side statuses: collection/FX/ops failures where the
+# provider is not to blame -- dropped from BOTH A_i sums, streak held.
+# timeout/budget error kinds classify here too (rule R1: the A_i skip
+# vocabulary is independent of the ruled CARRY kinds).
+_ATTENDANCE_SKIP_STATUSES = (
+    "error",
+    "fx_unavailable",
+    "manually_excluded",
+    "unimplemented",
+)
+
+# The COMPLETE status vocabulary the classifier maps deliberately. A
+# status outside this set (a seat vocabulary added by a LATER binary,
+# reachable only through replayed artifacts) fails CLOSED to skip --
+# A_i freezes, no silent penalty -- and the CLI's replay ingest warns
+# loudly on it (log + A_i freeze). This engine module stays pure (zero
+# I/O), so the log half lives at the CLI call site.
+ATTENDANCE_KNOWN_STATUSES = frozenset(
+    ("ok", "missing", CARRIED_STATUS)
+    + _ATTENDANCE_NO_PRICE_STATUSES
+    + _ATTENDANCE_SKIP_STATUSES
+)
+
+
+def classify_attendance_source(detail: Dict[str, Any]) -> Optional[str]:
+    """One artifact source row -> its attendance event code: EVENT_NO_PRICE
+    (state 2: counted 0 in A_i, streak advances), EVENT_SKIP (state 3: our
+    failure, dropped from the A_i sums, streak held), or None for the two
+    IMPLICIT rows -- a state-1 trusted print (the stamp lands in the
+    weight-state prices series, which is the presence record) and a
+    no-entry "missing" seat (absent from both: counted 0 in A_i, streak
+    held, never carried -- the methodology's ramp-in row; capture-config
+    drift shares this shape deliberately, presenting as a visibly falling
+    A_i tripwire rather than a silent skip).
+
+    Callers apply the artifact-LEVEL precedence rule first
+    (attendance_events_for_stamp): this per-row table is only meaningful
+    on a live snapshot.
+
+    A status this table does not know (a seat vocabulary added later)
+    fails CLOSED to EVENT_SKIP -- A_i freezes rather than silently
+    penalizing the provider; test-pinned."""
+    status = detail.get("status")
+    if status == "ok":
+        chosen = detail.get("chosen")
+        if not isinstance(chosen, dict):
+            # ok-no-chosen: read fine, zero eligible rows survived the
+            # screens (eligible_rows = 0 / all screened out).
+            return EVENT_NO_PRICE
+        verdict = detail.get("filter")
+        if isinstance(verdict, dict) and verdict.get("untrusted_currency"):
+            # Rule D1: chosen exists but no trustworthy filter value --
+            # a print the provider published that we cannot use.
+            return EVENT_NO_PRICE
+        # Trusted print: accepted, sigma-FENCED, and
+        # currency-mismatch-pending all count PRESENT (the fence holds a
+        # print out of the INDEX, never out of the presence record).
+        return None
+    if status in _ATTENDANCE_NO_PRICE_STATUSES:
+        return EVENT_NO_PRICE
+    if status == CARRIED_STATUS:
+        carried = detail.get("carried")
+        if (carried or {}).get("carry_basis") == CARRY_BASIS_NO_PRICE:
+            # Armed state-2 carry: the provider had no usable price and
+            # its booked vote was re-cast -- still absent.
+            return EVENT_NO_PRICE
+        # Collection-failure carry (failure_kind in the block): our
+        # failure, the seat's A_i is frozen.
+        return EVENT_SKIP
+    if status == "missing":
+        return None  # no entry: the implicit ramp-in row (docstring)
+    # Known our-side skip statuses (_ATTENDANCE_SKIP_STATUSES) land here
+    # -- and so does any status this table does not know, fail-closed as
+    # our-side skip (docstring; the CLI warns on the unknown ones).
+    return EVENT_SKIP
+
+
+def attendance_events_for_stamp(
+    sources: Sequence[Any],
+    *,
+    observation_missed: Any,
+    record_quarantined: Any,
+) -> Dict[str, str]:
+    """{source_id: event code} for one observation's source rows -- the
+    attendance classifier over a whole stamp, np/sk entries only (state-1
+    and no-entry stay implicit, the weight_state.events encoding).
+
+    PRECEDENCE RULE: artifact-level verdicts come first. An
+    observation_missed or record_quarantined stamp is state-3 SKIP for
+    EVERY source, whatever the per-source rows read (they all say
+    "missing" on such stamps -- there is no per-source status for a
+    lane-wide capture outage, and counting one against every provider's
+    A_i is exactly the penalty the methodology forbids)."""
+    out: Dict[str, str] = {}
+    if observation_missed or record_quarantined:
+        for detail in sources or []:
+            if isinstance(detail, dict) and detail.get("source_id") is not None:
+                out[str(detail["source_id"])] = EVENT_SKIP
+        return out
+    for detail in sources or []:
+        if not isinstance(detail, dict) or detail.get("source_id") is None:
+            continue
+        code = classify_attendance_source(detail)
+        if code is not None:
+            out[str(detail["source_id"])] = code
+    return out
+
+
+
 def apply_panel_jump_screen(
     current: Dict[str, Dict[str, Any]],
     reference_prints: Optional[Dict[str, Dict[str, Any]]],
@@ -1315,6 +1642,7 @@ def compute_observation(
     weight_state: Optional[Dict[str, Any]] = None,
     reference_prints: Optional[Dict[str, Dict[str, Any]]] = None,
     reference_label: Optional[str] = None,
+    carry_prints: Optional[Dict[str, Dict[str, Any]]] = None,
     schedule: Optional[Any] = None,
     calc_params: Optional[Dict[str, Any]] = None,
     compiled_screens: Optional[Dict[str, Any]] = None,
@@ -1404,6 +1732,12 @@ def compute_observation(
     obs_date, obs_minute_of_day = stamp_to_date_minute(obs_stamp)
     obs_hour, obs_minute = divmod(obs_minute_of_day, 60)
     stamp_iso = schedule.stamp_key(obs_stamp)
+    # ONE local for the artifact's observation_missed flag: the published
+    # byte and the attendance classifier's precedence input must be the
+    # same value by construction -- a quarantined stamp is NOT missed
+    # (the record may hold bytes; they are quarantined), and live/replay
+    # parity depends on both readers seeing the identical pair of flags.
+    observation_missed = snapshot is None and record_quarantined is None
     record_entry = record_source_for(params["record_sources"], obs_date)
 
     filter_terms = params["filter_terms"]
@@ -1526,6 +1860,35 @@ def compute_observation(
         compiled_screens if compiled_screens is not None else compile_screens(params)
     )
     member_ids = [m["source_id"] for m in params["members"]]
+    dynamic_params = params["dynamic_weights"]
+    carry_kinds = set(params.get("carry_forward_failure_kinds") or [])
+
+    # ONE attendance view per observation (METHODOLOGY.md section 8.6):
+    # None on knob-less lanes (the structural skip), computed ONCE here
+    # on minted lanes -- pre-advance, over all members -- and threaded
+    # into compute_panel_weights below (the scheduled_window
+    # amortization pattern). Two consumers here:
+    #
+    #   - the K_A hard exclusion, ARMED lanes only (the view's verdict is
+    #     armed-gated internally, rule R2): an excluded seat is OUT of
+    #     this observation entirely -- no weight row, no carry, no vote
+    #     -- until a new state-1 print (which still advances its windows
+    #     below, the recovery path) re-admits it at the NEXT observation
+    #     (the verdict is a pure pre-advance function of [.., obs)).
+    #     Applies in BOTH weight modes (an eligibility mechanism).
+    #   - the weight block's publication + armed allocation inputs.
+    attendance_view = compute_attendance_view(
+        weight_state,
+        member_ids,
+        obs_stamp=obs_stamp,
+        schedule=schedule,
+        dw_params=dynamic_params,
+    )
+    excluded_now: frozenset = frozenset(
+        sid
+        for sid in attendance_view or {}
+        if attendance_view[sid]["excluded"]
+    )
 
     source_entries = {
         s["source_id"]: s for s in (snapshot or {}).get("sources", [])
@@ -1610,17 +1973,74 @@ def compute_observation(
     )
     quarantined = {q["source_id"] for q in jump_block["quarantined"]}
 
+    # ARMED state-2 carry gate (METHODOLOGY.md section 8.6, rules
+    # D4/D5): when eta > 0 (single lever, R2) a seat that was READ FINE
+    # but produced no usable price this observation -- any of the four
+    # ruled shapes: ok-no-chosen, held_out, uncorroborated_jump,
+    # untrusted_currency -- re-casts its last ACCEPTED vote from the ONE
+    # carry book, under the D4-extended vector's CURRENT (fading)
+    # weight. The candidate set is resolved HERE, before the weight
+    # block, so the allocation domain can extend to it; the actual row
+    # emission is threaded per shape at the four exit sites below.
+    # Gates, each ruled: arming requires the carry knob pair minted (D5,
+    # load-validated; both re-checked here for replayed params), the
+    # book slice is window-bounded (carry_prints_for + the
+    # defense-in-depth re-check), a K_A-excluded seat never carries,
+    # fx_unavailable is state-3 and stays un-carried, a seat with no
+    # booked print silently does not carry, and a median lane's book
+    # entry must hold a full vote. Empty on every dark lane.
+    state2_carries: Dict[str, Dict[str, Any]] = {}
+    if (
+        attendance_armed(dynamic_params)
+        and carry_prints
+        and "carry_forward_window_hours" in params
+    ):
+        for source_id in member_ids:
+            resolved = resolutions[source_id]
+            if "excluded_reason" in resolved:
+                continue  # manually excluded: state-3, never carries
+            if (resolved.get("entry") or {}).get("status") != "ok":
+                continue  # error/missing/unimplemented: not state-2
+            if source_id in excluded_now:
+                continue  # the K_A cutoff stops carry
+            chosen = resolved.get("chosen")
+            if chosen is not None and chosen.get("fx_unavailable"):
+                continue  # our FX feed: state-3, un-carried (pinned)
+            state2 = (
+                chosen is None
+                or bool(chosen.get("held_out"))
+                or source_id in quarantined
+                or resolved.get("observation") is None
+            )
+            if not state2:
+                continue  # a trusted state-1 print: nothing to carry
+            entry_book = (carry_prints or {}).get(source_id)
+            if entry_book is None:
+                continue  # no booked print: silent no-carry
+            if not (
+                0
+                < obs_stamp - int(entry_book["stamp"])
+                <= carry_window_minutes(params)
+            ):
+                continue  # defense in depth, the state-3 gate's fence
+            if median_votes and not isinstance(entry_book.get("vote"), dict):
+                continue  # a median lane's carry re-casts a FULL vote
+            state2_carries[source_id] = entry_book
+
     # The eligible set (who printed a TRUSTED value this observation) --
     # quarantined members are OUT: at capture their rows never became
     # prints, and the calc-lane verdict must have the same reach.
+    # K_A-excluded members (armed lanes) are OUT too: exclusion is an
+    # eligibility mechanism -- a fresh print's re-admission lands at the
+    # NEXT observation, after the print has advanced the window below.
     eligible = [
         source_id
         for source_id in member_ids
         if resolutions[source_id].get("observation") is not None
         and source_id not in quarantined
+        and source_id not in excluded_now
     ]
 
-    dynamic_params = params["dynamic_weights"]
     weight_block = compute_panel_weights(
         weight_state,
         obs_stamp=obs_stamp,
@@ -1628,6 +2048,12 @@ def compute_observation(
         dw_params=dynamic_params,
         fallback_weights=dynamic_params["fallback_weights"],
         schedule=schedule,
+        # Rule D4: carry-casting state-2 seats join the allocation
+        # domain (sorted: fixed iteration order). Empty when dark.
+        carrying=sorted(state2_carries),
+        # The view computed above: one computation per observation
+        # serves exclusion, publication, and allocation.
+        attendance_view=attendance_view,
     )
     weight_of: Dict[str, Optional[float]] = {
         source_id: weight_block["weights"].get(source_id)
@@ -1640,6 +2066,54 @@ def compute_observation(
     prints_today: Dict[str, float] = {}
     filter_inputs: Dict[str, Optional[Tuple[float, str]]] = {}
     trusted_prints: Dict[str, Dict[str, Any]] = {}
+    carried_ids: set = set()
+
+    def _cast_state2_carry(detail: Dict[str, Any], source_id: str) -> bool:
+        """Thread ONE state-2 shape's exit through the armed carry gate
+        (METHODOLOGY.md section 8.6; the four call sites below are the
+        four ruled shapes). When the seat is carry-casting this stamp,
+        re-cast its booked price/band under its CURRENT (fading) weight
+        from the D4-extended vector -- never the booked weight, which is
+        the collection-failure machinery's rule -- and publish the
+        carried row with the carry_basis discriminator (the replay
+        byte). The seat enters ONLY the vote set: not prints_today, not
+        filter_inputs, not trusted_prints, not the claim floor
+        (carried_ids), never the jump-reference book (status carried).
+        Returns False on every dark lane (state2_carries empty) -- the
+        shape publishes its normal row byte-identically."""
+        entry_book = state2_carries.get(source_id)
+        if entry_book is None:
+            return False
+        # Deep copy like the collection-failure branch: one book entry
+        # can serve several consecutive carried observations, and those
+        # artifacts must not share nested mutables.
+        book_chosen = copy.deepcopy(entry_book["chosen"])
+        # The D4-extended vector holds a row for every carrying seat by
+        # construction (compute_panel_weights' domain), so this float()
+        # can never see None.
+        current_weight = float(weight_of[source_id])
+        detail["weight"] = weight_of[source_id]
+        detail["status"] = CARRIED_STATUS
+        detail["carried"] = {
+            "from": entry_book["stamp_iso"],
+            "age_minutes": int(obs_stamp) - int(entry_book["stamp"]),
+            "carry_basis": CARRY_BASIS_NO_PRICE,
+        }
+        detail["chosen"] = book_chosen
+        passing.append(
+            (
+                source_id,
+                current_weight,
+                float(book_chosen["usd_per_gpu_hr"]),
+            )
+        )
+        carried_ids.add(source_id)
+        if median_votes:
+            vote = copy.deepcopy(entry_book["vote"])
+            detail["vote"] = vote
+            vote_stddevs[source_id] = vote["conf_usd_gpu_hr"]
+        sources_block.append(detail)
+        return True
 
     for source_id in member_ids:
         resolved = resolutions[source_id]
@@ -1663,6 +2137,10 @@ def compute_observation(
             continue
         chosen = resolved.get("chosen")
         if chosen is not None and chosen.get("held_out"):
+            # Carry threading site 1 of 4 (D5): held_out -- thin_book /
+            # no_population_accounting (the order-book population gate).
+            if _cast_state2_carry(detail, source_id):
+                continue
             # Statistic hold-out (section 4): the gate/floor verdict with
             # its counts is the day's record for this seat.
             detail["status"] = "held_out"
@@ -1670,6 +2148,92 @@ def compute_observation(
             sources_block.append(detail)
             continue
         if chosen is None or chosen.get("fx_unavailable"):
+            # Carry threading site 2 of 4 (D5): ok-no-chosen -- the seat
+            # was read fine and zero eligible rows survived.
+            # fx_unavailable never reaches the gate (state-3, un-carried;
+            # state2_carries structurally excludes it).
+            if chosen is None and _cast_state2_carry(detail, source_id):
+                continue
+            # Carry-forward (METHODOLOGY.md section 8.6): a seat whose
+            # raw entry FAILED COLLECTION in a minted failure class
+            # re-casts its last accepted vote verbatim -- price, band,
+            # and weight from the carried-from artifact (the provider's
+            # posted price is a quote: it remains their live offer until
+            # they change it). Scope is deliberately narrow: entry status
+            # "error" with a matching failure_kind only. fx_unavailable
+            # shares this branch but is NOT a collection failure (the
+            # entry was ok; the FX record is what's missing) and stays
+            # un-carried; "missing"/"unimplemented" entries carry no
+            # failure_kind and can never match. The carried seat enters
+            # ONLY the vote set: not prints_today (warm-up mean), not
+            # filter_inputs (window advance), not trusted_prints (weight
+            # series), not the claim floor (a carried quorum must never
+            # keep a dark panel lit -- panel_dark counts observed passers
+            # only).
+            carried_from = None
+            if (
+                carry_kinds
+                and chosen is None
+                and (entry or {}).get("status") == "error"
+                and (entry or {}).get("failure_kind") in carry_kinds
+                # K_A exclusion stops EVERY carry basis ("no weight row,
+                # no carry, no vote"); the set is empty on every unarmed
+                # lane, so this clause is inert until a mint arms eta.
+                and source_id not in excluded_now
+            ):
+                carried_from = (carry_prints or {}).get(source_id)
+                if carried_from is not None and not (
+                    0
+                    < int(obs_stamp) - int(carried_from["stamp"])
+                    <= carry_window_minutes(params)
+                ):
+                    # Defense in depth: carry_prints_for already bounds
+                    # the book by the minted window, but the caller
+                    # contract must not be the ONLY fence -- a future
+                    # caller passing a raw carry_book would otherwise
+                    # re-cast arbitrarily stale prices under a minted
+                    # window that never fired.
+                    carried_from = None
+                if carried_from is not None and median_votes:
+                    # A median lane's carried seat must re-cast a full
+                    # vote; a book entry without one (fail closed --
+                    # update_carry_book admits vote-less entries only
+                    # from weighted-mean lanes) cannot serve here.
+                    if not isinstance(carried_from.get("vote"), dict):
+                        carried_from = None
+            if carried_from is not None:
+                # Deep copy like the book's own admission: the same book
+                # entry can serve several consecutive carried hours, and
+                # those artifacts must not share nested mutables.
+                book_chosen = copy.deepcopy(carried_from["chosen"])
+                detail["weight"] = float(carried_from["weight"])
+                detail["status"] = CARRIED_STATUS
+                detail["carried"] = {
+                    "from": carried_from["stamp_iso"],
+                    "age_minutes": int(obs_stamp)
+                    - int(carried_from["stamp"]),
+                    "failure_kind": entry["failure_kind"],
+                }
+                # The quarantine shape (chosen WITHOUT a filter verdict):
+                # replay's advance_panel_state_from_published requires
+                # both, so a carried seat advances neither the filter
+                # window nor the weight series -- a stale price is not a
+                # print, it is a held vote.
+                detail["chosen"] = book_chosen
+                passing.append(
+                    (
+                        source_id,
+                        float(carried_from["weight"]),
+                        float(book_chosen["usd_per_gpu_hr"]),
+                    )
+                )
+                carried_ids.add(source_id)
+                if median_votes:
+                    vote = copy.deepcopy(carried_from["vote"])
+                    detail["vote"] = vote
+                    vote_stddevs[source_id] = vote["conf_usd_gpu_hr"]
+                sources_block.append(detail)
+                continue
             detail["status"] = (
                 "fx_unavailable"
                 if chosen and chosen.get("fx_unavailable")
@@ -1692,6 +2256,12 @@ def compute_observation(
             sources_block.append(detail)
             continue
         if source_id in quarantined:
+            # Carry threading site 3 of 4 (D5): uncorroborated_jump --
+            # the L5 quarantine. The carried row replaces the would-be
+            # print; the record still holds the quarantined evidence, and
+            # the jump_screen block discloses the verdict either way.
+            if _cast_state2_carry(detail, source_id):
+                continue
             # L5 at calc: held out for THIS observation only; the would-be
             # print stays in the artifact as evidence, but it enters
             # neither the filter window nor the weight series (capture
@@ -1706,6 +2276,10 @@ def compute_observation(
         # untrusted/mismatch paths leave it None (no vote is cast there).
         vote_tail: Optional[List[float]] = None
         if observation is None:
+            # Carry threading site 4 of 4 (D5): untrusted_currency --
+            # rule D1's chosen-but-untrusted shape.
+            if _cast_state2_carry(detail, source_id):
+                continue
             # Rule D1, fail-closed: no trustworthy value exists in
             # window terms. Held out; the window is preserved.
             verdict: Dict[str, Any] = {
@@ -1802,7 +2376,12 @@ def compute_observation(
             # AND sigma-fenced (the fence holds a print out of the INDEX,
             # never out of the weight series; R-winsor bounds it).
             trusted_prints[source_id] = series_print(price, observation)
-        if verdict["accepted"]:
+        # A K_A-excluded seat (armed lanes only; empty set otherwise)
+        # casts NO vote this observation even on a fresh accepted print:
+        # the exclusion verdict is pre-advance, the print above still
+        # advances its windows and the weight series (the recovery path),
+        # and the NEXT observation re-admits it.
+        if verdict["accepted"] and source_id not in excluded_now:
             passing.append((source_id, float(weight_of[source_id]), price))
             if median_votes:
                 # The compute_day fx-factor rule verbatim: a non-USD vote
@@ -1881,8 +2460,13 @@ def compute_observation(
         )
 
     # Claim floor -> explicit dark artifact (design section 3 step 8).
+    # Carried seats are OUT of the count (conservative): carry may move
+    # the median a printing panel composes, but a panel that would have
+    # gone dark on its observed seats alone goes dark still -- carried
+    # votes must never keep a dying panel looking alive. With no carry
+    # knob carried_ids is empty and the count is len(passing) verbatim.
     min_claim = params["min_sources_to_claim"]
-    if len(passing) >= min_claim:
+    if len(passing) - len(carried_ids) >= min_claim:
         composite = (
             median_stddev_composite(
                 passing,
@@ -1918,10 +2502,28 @@ def compute_observation(
             / passing_total,
             6,
         )
+        # Basis mix: how many of this observation's votes were observed
+        # this hour vs carried from a prior print -- the public
+        # continuity disclosure. CONDITIONAL on the minted knob like
+        # iqm_alpha (a knob-less lane's artifact bytes must not grow
+        # keys), but UNCONDITIONAL per knob-carrying observation:
+        # {observed: N, carried: 0} on an all-observed hour is the
+        # disclosure working, not noise.
+        if carry_kinds:
+            composite["vote_basis"] = {
+                "observed": len(passing) - len(carried_ids),
+                "carried": len(carried_ids),
+            }
 
     # Advance the observation-mode weight state with this observation's
     # pinned facts -- AFTER the vector was computed (nothing observed at t
-    # enters t's weights), the same order replay applies.
+    # enters t's weights), the same order replay applies. On a minted
+    # attendance lane the advance also records this stamp's np/sk
+    # classifications, decided from the SAME source rows the artifact
+    # publishes (attendance_events_for_stamp is the one classifier replay
+    # runs over the published rows -- live/replay parity by
+    # construction); knob-less lanes pass None and their state never
+    # grows the events key (the D2 dark contract).
     advance_panel_weight_state(
         weight_state,
         obs_stamp=obs_stamp,
@@ -1929,6 +2531,15 @@ def compute_observation(
         vector=weight_block["weights"],
         mode=weight_block["mode"],
         dw_params=dynamic_params,
+        events=(
+            attendance_events_for_stamp(
+                sources_block,
+                observation_missed=observation_missed,
+                record_quarantined=record_quarantined,
+            )
+            if attendance_minted(dynamic_params)
+            else None
+        ),
     )
 
     return {
@@ -1956,7 +2567,7 @@ def compute_observation(
         ),
         # A quarantined stamp is NOT missed: the record may hold bytes;
         # they are quarantined by config (F6), a recorded fact of its own.
-        "observation_missed": snapshot is None and record_quarantined is None,
+        "observation_missed": observation_missed,
         "record_quarantined": record_quarantined,
         "panel_dark": composite is None,
         "index": composite,

--- a/src/gpu_index/index/panel_config.py
+++ b/src/gpu_index/index/panel_config.py
@@ -129,6 +129,15 @@ Shape (see gpu_index.index.panel.panel_calc_params for what rides the artifact):
                       dynamic_weights.history_days per-source history;
                       requires median_ci_votes, and dw_history requires
                       the dynamic_weights block),
+                      carry_forward_window_hours? +
+                      carry_forward_failure_kinds? (CONDITIONAL pair,
+                      both or neither: a member whose raw capture entry
+                      failed collection in one of the named failure
+                      classes re-casts its last accepted vote for up to
+                      the window, in (0, 168] hours and never past
+                      dynamic_weights.history_days*24; kinds are
+                      gpu_index.observatory.collect's vocabulary.
+                      METHODOLOGY.md section 8.6),
                       manual_verify_pct?, fx_lane (REQUIRED
                       ecb|none), fx_max_staleness_days?,
                       availability_verified_sources? (OPTIONAL [member
@@ -150,7 +159,16 @@ Shape (see gpu_index.index.panel.panel_calc_params for what rides the artifact):
                       (REQUIRED -- rule A1: panel weights recompute at
                       every observation, a panel without the block has no
                       weight law; includes the A2 attendance_floor,
-                      validated by gpu_index.index.weights.validate_attendance_floor).
+                      validated by gpu_index.index.weights.validate_attendance_floor,
+                      and the OPTIONAL attendance knob triple
+                      attendance_half_life_hours + attendance_eta +
+                      no_price_exclusion_hours -- all three or none,
+                      validated by
+                      gpu_index.index.weights.validate_attendance_params;
+                      attendance_eta > 0 additionally REQUIRES the carry
+                      pair above with no_price_exclusion_hours <=
+                      carry_forward_window_hours, METHODOLOGY.md
+                      sections 8.6-8.7).
                       calc.drift_scan_observations is a RETIRED location,
                       refused loudly (see the top-level key above).
 
@@ -321,6 +339,10 @@ _CALC_KEYS = frozenset(
         "statistic_params",
         "dynamic_weights",
         "availability_verified_sources",
+        # Carry-forward knob pair (METHODOLOGY.md section 8.6):
+        # CONDITIONAL, both-or-neither, validated in _validate_calc.
+        "carry_forward_window_hours",
+        "carry_forward_failure_kinds",
         # Retired locations -- recognized so their DEDICATED refusals
         # (naming the successor) fire instead of the generic unknown-key
         # message.
@@ -357,6 +379,13 @@ _DYNAMIC_WEIGHTS_KEYS = frozenset(
         "max_abs_log_return",
         "source_weight_caps",
         "attendance_floor",
+        # Attendance-weighting knob triple (METHODOLOGY.md section 8.6;
+        # names cross-repo frozen). Conditional: all three or none --
+        # gpu_index.index.weights.validate_attendance_params is the one
+        # home for the rule and its bounds.
+        "attendance_half_life_hours",
+        "attendance_eta",
+        "no_price_exclusion_hours",
     }
 )
 _JUMP_SCREEN_KEYS = frozenset(
@@ -1054,6 +1083,79 @@ def _validate_calc(
                 "calc.dynamic_weights -- the vote tail spans "
                 "dynamic_weights.history_days of per-source history"
             )
+    if ("carry_forward_window_hours" in calc) != (
+        "carry_forward_failure_kinds" in calc
+    ):
+        # Carry-forward (METHODOLOGY.md section 8.6): the window without
+        # a failure scope (or a scope without a window) is half a rule --
+        # an author reading either key alone would misread what carries.
+        raise PanelConfigError(
+            "calc.carry_forward_window_hours and "
+            "calc.carry_forward_failure_kinds ride together (both or "
+            "neither) -- a carry window needs a failure scope and a "
+            "failure scope needs a window"
+        )
+    if "carry_forward_window_hours" in calc:
+        window_hours = calc["carry_forward_window_hours"]
+        if not (
+            isinstance(window_hours, (int, float))
+            and not isinstance(window_hours, bool)
+            and 0 < window_hours <= 168
+        ):
+            raise PanelConfigError(
+                "calc.carry_forward_window_hours must be a number in "
+                f"(0, 168] (hours; 168 = the 7-day outer precedent), "
+                f"got {window_hours!r}"
+            )
+        # One vocabulary home: the capture lane speaks first
+        # (gpu_index.observatory.collect classifies), the calc lane must
+        # use the same words -- the QUARANTINE_REASON pattern. Lazy
+        # import like the statistic registry above.
+        from gpu_index.observatory.collect import VALID_FAILURE_KINDS
+
+        kinds = calc["carry_forward_failure_kinds"]
+        if (
+            not isinstance(kinds, list)
+            or not kinds
+            or not all(isinstance(k, str) and k for k in kinds)
+        ):
+            raise PanelConfigError(
+                "calc.carry_forward_failure_kinds must be a non-empty "
+                f"list of failure-kind strings, got {kinds!r}"
+            )
+        if len(set(kinds)) != len(kinds):
+            raise PanelConfigError(
+                "calc.carry_forward_failure_kinds carries duplicate "
+                f"entries: {kinds!r}"
+            )
+        unknown = sorted(set(kinds) - set(VALID_FAILURE_KINDS))
+        if unknown:
+            raise PanelConfigError(
+                f"calc.carry_forward_failure_kinds names unknown kind(s) "
+                f"{unknown} -- valid kinds are "
+                f"{sorted(VALID_FAILURE_KINDS)} "
+                "(gpu_index.observatory.collect's classification "
+                "vocabulary)"
+            )
+        # Bounded-replay fence: the carry book is engine-consulted state,
+        # and the CLI's state window rebuilds ONLY dw
+        # history_days*1440 (+ horizons + margin) of it -- a carry window
+        # reaching past that would make a cold replay miss book entries a
+        # live run had, forking published bytes. history_days*24 is the
+        # conservative bound (the horizons+margin slack is deliberately
+        # not spent).
+        dw_block = calc.get("dynamic_weights") or {}
+        history_days = dw_block.get("history_days")
+        if (
+            isinstance(history_days, int)
+            and window_hours > history_days * 24
+        ):
+            raise PanelConfigError(
+                f"calc.carry_forward_window_hours ({window_hours}) exceeds "
+                f"dynamic_weights.history_days*24 ({history_days * 24}) -- "
+                "the carry book must rebuild fully inside the bounded "
+                "replay's state window or cold replays fork published bytes"
+            )
     if calc.get("manual_verify_pct") is not None:
         _require_number(
             calc["manual_verify_pct"], "calc.manual_verify_pct", lo=0
@@ -1085,6 +1187,35 @@ def _validate_calc(
     _validate_dynamic_weights(
         calc.get("dynamic_weights"), members, member_ids, schedule
     )
+    # Attendance arming gate (rule D5, METHODOLOGY.md section 8.6):
+    # eta > 0 switches on the state-2 carry read path, and carry is ONE
+    # mechanism with ONE book and ONE wall-time window -- an armed lane
+    # without the carry knob pair would have no book to serve its fading
+    # seats, and an exclusion window wider than the carry window would
+    # keep serving carried votes for a seat the cutoff already ruled
+    # dead. Cross-LEVEL by necessity (the carry pair lives in calc, the
+    # attendance triple in calc.dynamic_weights), so the rule sits here
+    # rather than in the dw validator.
+    dw_validated = calc["dynamic_weights"]
+    if "attendance_eta" in dw_validated and dw_validated["attendance_eta"] > 0:
+        if "carry_forward_window_hours" not in calc:
+            raise PanelConfigError(
+                "calc.dynamic_weights.attendance_eta > 0 requires the "
+                "carry knob pair (calc.carry_forward_window_hours + "
+                "calc.carry_forward_failure_kinds) -- armed attendance "
+                "carries state-2 seats from the ONE carry book (rule D5)"
+            )
+        if float(dw_validated["no_price_exclusion_hours"]) > float(
+            calc["carry_forward_window_hours"]
+        ):
+            raise PanelConfigError(
+                f"calc.dynamic_weights.no_price_exclusion_hours "
+                f"({dw_validated['no_price_exclusion_hours']!r}) must not "
+                f"exceed calc.carry_forward_window_hours "
+                f"({calc['carry_forward_window_hours']!r}) -- the hard "
+                "cutoff must fire at or before the carry window expires "
+                "(rule D5)"
+            )
     if "drift_scan_observations" in calc:
         # Retired location (amended into the mints before any observation
         # published): the drift-scan bound is an OPERATIONAL knob and must
@@ -1271,7 +1402,11 @@ def _validate_dynamic_weights(
         # observation; a panel without the block has no weight law.
         raise PanelConfigError("calc.dynamic_weights is required for panels")
     _refuse_unknown_keys(dw, _DYNAMIC_WEIGHTS_KEYS, "calc.dynamic_weights")
-    from gpu_index.index.weights import VALID_WEIGHT_SCHEMES, validate_attendance_floor
+    from gpu_index.index.weights import (
+        VALID_WEIGHT_SCHEMES,
+        validate_attendance_floor,
+        validate_attendance_params,
+    )
 
     if dw.get("scheme") not in VALID_WEIGHT_SCHEMES:
         raise PanelConfigError(
@@ -1373,6 +1508,15 @@ def _validate_dynamic_weights(
     # the one home of the rule and its bounds.
     try:
         validate_attendance_floor(dw)
+    except ValueError as exc:
+        raise PanelConfigError(str(exc)) from exc
+    # Attendance-weighting knob triple: OPTIONAL, all three or none,
+    # bounds owned by gpu_index.index.weights (one home, the
+    # attendance_floor pattern). The eta>0-requires-carry-knobs rule is
+    # cross-LEVEL (the carry pair lives in calc) and validated by the
+    # caller, _validate_calc.
+    try:
+        validate_attendance_params(dw)
     except ValueError as exc:
         raise PanelConfigError(str(exc)) from exc
     min_span_minutes = (

--- a/src/gpu_index/index/weights.py
+++ b/src/gpu_index/index/weights.py
@@ -532,14 +532,26 @@ def allocate_weights(
     weight_min: float,
     weight_max: float,
     source_caps: Optional[Dict[str, float]] = None,
+    attendance_factors: Optional[Dict[str, float]] = None,
+    attendance_eta: float = 0.0,
 ) -> Tuple[Dict[str, float], Dict[str, Any]]:
-    """Softmax allocation (METHODOLOGY.md §8.6) plus the risk-cap layer: softmax(gamma * Q)
+    """Softmax allocation (METHODOLOGY.md §8.7) plus the risk-cap layer: softmax(gamma * Q)
     shares over the eligible set, everyone floored at weight_min, the
     remainder distributed by share, then caps applied by iteratively
     capping violators at cap_i = min(weight_max, source_caps[i]) and
     redistributing their excess to the uncapped proportionally to share.
     The capped set grows monotonically, so the loop terminates within N
     passes. Full precision throughout; the caller rounds ONCE at the end.
+
+    ATTENDANCE (METHODOLOGY.md §8.7): ``attendance_factors`` ({sid: A_i
+    in [0, 1], FULL precision}; named to stay clear of this module's
+    attendance() ratio helper) and ``attendance_eta`` arm the
+    attendance-weighted variant, dispatched to
+    _allocate_weights_attendance below. The gate is STRUCTURAL: with the
+    factors None (every day-mode caller -- the frozen daily series never
+    passes them) or eta == 0 NOTHING new is computed -- no log, no
+    per-seat floor arithmetic -- and this body runs byte-identically to
+    the pre-attendance engine.
 
     Per-source caps are optional RISK haircuts (e.g. a thin-order-book
     marketplace cap): predictiveness allocates WITHIN risk bounds, never
@@ -563,6 +575,16 @@ def allocate_weights(
         (unsatisfiable arithmetic; the validator refuses such configs at
         load — this is runtime armor) publishes exactly uniform 1/N.
     """
+    if attendance_factors is not None and attendance_eta > 0:
+        return _allocate_weights_attendance(
+            scores,
+            gamma=gamma,
+            weight_min=weight_min,
+            weight_max=weight_max,
+            source_caps=source_caps,
+            attendance_factors=attendance_factors,
+            eta=attendance_eta,
+        )
     ids = sorted(scores)
     n = len(ids)
     flags: Dict[str, Any] = {"degenerate_allocation": None, "capped": []}
@@ -595,8 +617,42 @@ def allocate_weights(
     shares = {sid: exp_shares[sid] / share_total for sid in ids}
     spread = 1.0 - n * weight_min
     weights = {sid: weight_min + spread * shares[sid] for sid in ids}
+    _redistribute_capped_excess(ids, weights, shares, caps, flags)
+    return weights, flags
+
+
+def _redistribute_capped_excess(
+    ids: List[str],
+    weights: Dict[str, float],
+    shares: Dict[str, float],
+    caps: Dict[str, float],
+    flags: Dict[str, Any],
+) -> None:
+    """The iterative cap solver, shared VERBATIM by the legacy and the
+    attendance-armed allocators (the two bodies were byte-identical
+    copies): cap violators at cap_i, hand their excess to the uncapped
+    proportionally to share. The capped set grows monotonically, so the
+    loop terminates within len(ids) passes. Mutates ``weights`` and sets
+    flags["capped"]. FLOAT-OP ORDER IS LOAD-BEARING: the legacy path's
+    bytes are golden-pinned and the armed path's A_i=1 reduction is
+    bit-parity-pinned against it, so any edit here must keep the exact
+    operation sequence.
+
+    Corners, each inherited with its original rationale:
+      - every source at its cap: the mass invariant plus the callers'
+        cap-mass gate force sum(caps) == 1 within float dust (the
+        exactly-1.0 corner: three 0.30s + a 0.10) -- the honest
+        allocation IS the caps; the residual excess is dust.
+      - pool underflow: extreme-but-finite gamma can underflow every
+        non-max share to exactly 0.0; the excess is still conserved
+        deterministically by spreading it equally over the uncapped
+        rather than darking the publish on a divide. (On the armed path
+        an A_i = 0 seat that picks up dust here exceeds its 0 cap and is
+        capped back to its explicit 0.0 row on the next pass --
+        termination untouched.)
+    """
     capped: List[str] = []
-    for _ in range(n):
+    for _ in range(len(ids)):
         over = [
             sid
             for sid in ids
@@ -611,25 +667,130 @@ def allocate_weights(
             capped.append(sid)
         uncapped = [sid for sid in ids if sid not in capped]
         if not uncapped:
-            # Every source is at its cap. The mass invariant plus the
-            # cap-mass gate above force sum(caps) == 1 within float dust
-            # (the exactly-1.0 corner: three 0.30s +
-            # a 0.10) — the honest allocation IS the caps themselves, so
-            # publish them; the residual excess is dust by construction.
             flags["capped"] = sorted(capped)
-            return weights, flags
+            return
         pool = sum(shares[sid] for sid in uncapped)
         if pool <= 0.0:
-            # Extreme-but-finite gamma can underflow every non-max share to
-            # exactly 0.0 (exp(gamma * dQ) at dQ << 0); the excess must
-            # still be conserved deterministically — spread it equally over
-            # the uncapped rather than darking the publish on a divide.
             for sid in uncapped:
                 weights[sid] += excess / len(uncapped)
             continue
         for sid in uncapped:
             weights[sid] += excess * shares[sid] / pool
     flags["capped"] = sorted(capped)
+
+
+def _allocate_weights_attendance(
+    scores: Dict[str, float],
+    *,
+    gamma: float,
+    weight_min: float,
+    weight_max: float,
+    source_caps: Optional[Dict[str, float]],
+    attendance_factors: Dict[str, float],
+    eta: float,
+) -> Tuple[Dict[str, float], Dict[str, Any]]:
+    """The ARMED attendance-weighted allocation (METHODOLOGY.md §8.7);
+    reached only via allocate_weights' structural gate, eta > 0. The
+    domain (``scores`` keys) is the caller's D4-extended voting set
+    (eligible union carry-casting seats). Deviations from the legacy
+    body, each ruled:
+
+      1. EXPONENT: x_i = gamma*(Q_i - Q_max) + eta*ln(A_i), stabilized
+         by subtracting max_i x_i over the COMBINED exponent (both terms
+         <= 0 after the shift, so exp never overflows at any gamma/eta).
+         An A_i = 0 seat is dropped from the softmax BEFORE any log (ln
+         is never called on 0) -- its cap and floor are 0 and it keeps
+         an explicit 0.0 weight row when in the domain (a disclosed
+         invariant change while armed: the engine otherwise never
+         publishes a literal-0 weight).
+      2. CEILING: cap_i = min(weight_max * A_i, source_caps_i) -- the
+         risk caps stay a separate upper bound.
+      3. FLOOR COLLAPSES WITH THE CEILING (rule D6): per-seat floor_i =
+         min(weight_min, cap_i); a fading seat rides smoothly to
+         near-zero instead of hitting a second exclusion cliff at
+         A_i ~ w_min/w_max. The legacy any-cap-below-floor uniform armor
+         is therefore NOT here -- unreachable from attendance by
+         construction (floors <= caps), it remains config armor on the
+         legacy path only. The spread is written as (1 - n*w_min) +
+         sum(w_min - floor_i) so at A_i = 1 for all i every intermediate
+         float -- caps, floors, exponents, spread -- reduces BIT-EXACTLY
+         to the legacy body (the A=1 bit-parity pin).
+      4. INFEASIBLE CEILINGS (rule D7): sum(cap) < 1 publishes the
+         cap-proportional expansion cap_i / sum(caps) -- the methodology's
+         c_i/C formula (w_max*A_i / sum(A_j*w_max) when no risk cap
+         binds); allocation pinned at the ceilings, Q/eta have no slack
+         on those stamps only; flagged.
+      5. CORNER GUARDS: sum(cap) == 0 (every domain seat at A_i = 0)
+         publishes uniform-over-domain with a fallback_reason
+         (config-armor semantics -- division guarded); n*w_min > 1 keeps
+         the legacy uniform armor verbatim.
+    """
+    ids = sorted(scores)
+    n = len(ids)
+    flags: Dict[str, Any] = {"degenerate_allocation": None, "capped": []}
+    if n == 0:
+        return {}, flags
+    factors = {sid: float(attendance_factors[sid]) for sid in ids}
+    caps = {
+        sid: min(
+            float(weight_max) * factors[sid],
+            float((source_caps or {}).get(sid, weight_max)),
+        )
+        for sid in ids
+    }
+    uniform = {sid: 1.0 / n for sid in ids}
+    if n * weight_min > 1.0 + _CAP_EPS:
+        flags["degenerate_allocation"] = "uniform"
+        flags["fallback_reason"] = (
+            f"bounds unsatisfiable for n={n}: n*w_min={n * weight_min:.6f}"
+        )
+        return uniform, flags
+    cap_mass = sum(caps.values())
+    if cap_mass <= _CAP_EPS:
+        # Every domain seat at A_i = 0 (a first-print panel corner): no
+        # ceiling can hold any mass -- publish uniform loudly rather
+        # than divide by zero.
+        flags["degenerate_allocation"] = "uniform"
+        flags["fallback_reason"] = (
+            f"attendance cap mass 0 for n={n}: every domain seat at "
+            "A_i=0; uniform weights published"
+        )
+        return uniform, flags
+    if cap_mass < 1.0 - _CAP_EPS:
+        # Rule D7: the existing cap-proportional branch IS the
+        # methodology's c_i/C expansion -- expanded ceilings sum to
+        # exactly 1, the allocation is pinned at the ceilings, and the
+        # stamp is audit-visible forever.
+        flags["degenerate_allocation"] = "cap_proportional"
+        # The reason string is the LEGACY text verbatim (the caps here
+        # are the attendance-scaled ones): at A_i = 1 for all i the
+        # armed body must reduce bit-exactly to the legacy body, flags
+        # included -- the fallback_reason rides the artifact.
+        flags["fallback_reason"] = (
+            f"cap mass {cap_mass:.6f} < 1 for n={n}: weights scaled "
+            "proportionally to the caps"
+        )
+        return {sid: caps[sid] / cap_mass for sid in ids}, flags
+    floors = {sid: min(float(weight_min), caps[sid]) for sid in ids}
+    q_max = max(scores.values())
+    # A_i = 0 seats leave the softmax BEFORE the log (docstring item 1);
+    # cap_mass >= 1 - eps above guarantees at least one A_i > 0 seat.
+    exponents = {
+        sid: gamma * (scores[sid] - q_max) + eta * math.log(factors[sid])
+        for sid in ids
+        if factors[sid] > 0.0
+    }
+    x_max = max(exponents.values())
+    exp_shares = {sid: math.exp(x - x_max) for sid, x in exponents.items()}
+    share_total = sum(exp_shares[sid] for sid in exp_shares)
+    shares = {sid: exp_shares.get(sid, 0.0) / share_total for sid in ids}
+    deficit_total = sum(weight_min - floors[sid] for sid in ids)
+    spread = (1.0 - n * weight_min) + deficit_total
+    weights = {sid: floors[sid] + spread * shares[sid] for sid in ids}
+    # The SAME iterative cap solver as the legacy body (one home --
+    # _redistribute_capped_excess): per-seat attendance ceilings ride in
+    # through ``caps``; the A=1 bit-parity pin covers the sharing.
+    _redistribute_capped_excess(ids, weights, shares, caps, flags)
     return weights, flags
 
 
@@ -1021,6 +1182,115 @@ def validate_attendance_floor(dw_params: Dict[str, Any]) -> float:
     return float(value)
 
 
+# The attendance-weighting knob triple (METHODOLOGY.md §8.6). Names are
+# CROSS-REPO FROZEN (the published records, this engine, and the panel
+# configs must agree verbatim); the three ride together as one
+# conditional embed -- key ABSENT means the attendance-free legacy
+# engine byte-identically (the D2 dark contract).
+ATTENDANCE_PARAM_KEYS = (
+    "attendance_half_life_hours",
+    "attendance_eta",
+    "no_price_exclusion_hours",
+)
+
+# weight_state["events"] codes: state-2-with-entry ("np": read fine, no
+# usable price -- the streak advances) and state-3 ("sk": OUR failure --
+# dropped from the A_i sums, streak held). State-1 is implicit (stamp
+# present in state prices on the grid); a no-entry stamp is implicit too
+# (absent from both -- counted 0 in A_i, streak held, the ramp-in row).
+EVENT_NO_PRICE = "np"
+EVENT_SKIP = "sk"
+VALID_EVENT_CODES = (EVENT_NO_PRICE, EVENT_SKIP)
+
+
+def attendance_minted(dw_params: Optional[Dict[str, Any]]) -> bool:
+    """Whether a dynamic-weights param set carries the minted attendance
+    knob triple -- THE predicate for every attendance codepath, one home
+    (a hand-spelled key check drifting from this one is the silent-fork
+    class). Presence of ONE member decides because validation refuses
+    partial sets."""
+    return "attendance_half_life_hours" in (dw_params or {})
+
+
+def attendance_armed(dw_params: Optional[Dict[str, Any]]) -> bool:
+    """Minted AND attendance_eta > 0 -- rule R2's single arming lever
+    (carry, K_A exclusion, ceiling scaling, and the tilt all gate on
+    it)."""
+    return (
+        attendance_minted(dw_params)
+        and float(dw_params["attendance_eta"]) > 0
+    )
+
+
+def validate_attendance_params(
+    dw_params: Dict[str, Any],
+) -> Optional[Dict[str, float]]:
+    """Load-time fence for the attendance knob triple (METHODOLOGY.md
+    section 8.6), the attendance_floor pattern: called by the PANEL
+    config loader, one home for the bounds. Returns None when the triple
+    is wholly absent (the knob-less legacy shape), else the validated
+    float triple; raises on a partial set or an out-of-range value.
+
+    Bounds, each load-bearing: the half-life and the exclusion window are
+    wall-time HOURS (rule R3 -- an observation-counted knob silently
+    changes meaning at every cadence mint) and must fit inside the
+    history window the events state is retained for (the determinism
+    bound needs events coverage over the exclusion window); eta >= 0 with
+    eta == 0 the dark posture (rule D2). The eta>0-requires-carry-knobs
+    rule (D5) is validated at the CALC level in panel_config -- the carry
+    pair lives one nesting level up from this block."""
+    present = [k for k in ATTENDANCE_PARAM_KEYS if k in dw_params]
+    if not present:
+        return None
+    if len(present) != len(ATTENDANCE_PARAM_KEYS):
+        missing = sorted(set(ATTENDANCE_PARAM_KEYS) - set(present))
+        raise ValueError(
+            f"dynamic_weights attendance knobs ride together (all three of "
+            f"{list(ATTENDANCE_PARAM_KEYS)} or none): missing {missing}"
+        )
+    history_hours = int(dw_params["history_days"]) * 24
+    half_life = dw_params["attendance_half_life_hours"]
+    if not (
+        isinstance(half_life, (int, float))
+        and not isinstance(half_life, bool)
+        and math.isfinite(half_life)
+        and 0 < half_life <= history_hours
+    ):
+        raise ValueError(
+            f"dynamic_weights.attendance_half_life_hours must be a finite "
+            f"number in (0, history_days*24 = {history_hours}], got "
+            f"{half_life!r}"
+        )
+    eta = dw_params["attendance_eta"]
+    if not (
+        isinstance(eta, (int, float))
+        and not isinstance(eta, bool)
+        and math.isfinite(eta)
+        and eta >= 0
+    ):
+        raise ValueError(
+            f"dynamic_weights.attendance_eta must be a finite number >= 0, "
+            f"got {eta!r}"
+        )
+    exclusion = dw_params["no_price_exclusion_hours"]
+    if not (
+        isinstance(exclusion, (int, float))
+        and not isinstance(exclusion, bool)
+        and math.isfinite(exclusion)
+        and 0 < exclusion <= history_hours
+    ):
+        raise ValueError(
+            f"dynamic_weights.no_price_exclusion_hours must be a finite "
+            f"number in (0, history_days*24 = {history_hours}], got "
+            f"{exclusion!r}"
+        )
+    return {
+        "attendance_half_life_hours": float(half_life),
+        "attendance_eta": float(eta),
+        "no_price_exclusion_hours": float(exclusion),
+    }
+
+
 def attendance(
     state_prices: Dict[str, Dict[int, Dict[str, Any]]],
     sid: str,
@@ -1062,6 +1332,176 @@ def attendance(
     scheduled = len(scheduled_set)
     ratio = 1.0 if scheduled == 0 else printed / scheduled
     return {"printed": printed, "scheduled": scheduled, "ratio": ratio}
+
+
+def compute_attendance_view(
+    weight_state: Dict[str, Any],
+    ids: Sequence[str],
+    *,
+    obs_stamp: int,
+    schedule: Any,
+    dw_params: Dict[str, Any],
+    scheduled_window: Optional[Sequence[int]] = None,
+) -> Optional[Dict[str, Dict[str, Any]]]:
+    """The attendance-weighting per-source view at one observation
+    (METHODOLOGY.md section 8.6): {sid: {factor, streak, excluded}} for
+    every id, or None when the lane's dw_params lack the minted knob
+    triple (the structural skip -- a knob-less lane never computes ANY
+    of this, the D2 dark contract).
+
+    factor -- the EWMA attendance A_i, exact: over the era-aware,
+    genesis-clipped scheduled stamps in the HALF-OPEN pre-advance window
+    [obs - history_days*1440, obs), with the decay
+    w(s) = 2**(-(obs - s) / H_A_minutes),
+
+        A_i = sum_{s not skip} w(s)*present_i(s) / sum_{s not skip} w(s)
+
+    where present_i(s) = 1 exactly when s sits in the source's
+    weight-state PRICES series (the trusted-print presence record --
+    accepted, sigma-fenced, and mismatch-pending prints alike), state-3
+    stamps (events code "sk") drop from numerator AND denominator (the
+    only reading under which an always-present provider scores exactly
+    1.0 through our-failure stamps), and every other scheduled stamp --
+    "np" events and no-entry stamps alike -- counts 0 (the ramp-in rule).
+    Denominator 0 (lane genesis / all-skip window) = 1.0, the existing
+    ratio's genesis convention. FULL precision: the allocator consumes
+    this value raw; the published 9dp attendance_factor is
+    disclosure-only rounding at publication.
+
+    Perf: ONE decay table per observation, shared across all sources --
+    one pow per stamp, not per stamp*source; fixed iteration order over
+    the sorted stamp window; pure Python, no incremental accumulator
+    (bounded replay rebuilds from window history). Bit-identical to the
+    naive per-source recompute (test-pinned).
+
+    streak / excluded -- the K_A hard cutoff: a BACKWARD walk over the
+    SAME scheduled window the EWMA reads -- [obs - history_days*1440,
+    obs), half-open, pre-advance, era-aware, genesis-clipped -- in which
+    SKIP stamps ("sk" events, our failures) consume NOTHING. Each
+    non-skip stamp contributes ITS OWN era's spacing (the gap to its
+    previous scheduled stamp, deterministic from the schedule alone; a
+    genesis stamp with no predecessor contributes 0 -- conservative,
+    later exclusion):
+
+      - first state-1 stamp (in prices)      => NOT excluded (resolve);
+      - accumulated non-skip span >= K_A
+        with >= 1 state-2 seen               => EXCLUDED (resolve);
+      - window exhausted, no state-1: when the window is the FULL
+        history span (genesis_stamp <= obs - history*1440), EXCLUDED
+        iff >= 1 state-2 was seen -- a seat with zero usable prints
+        across the entire history window is past any K_A <= history
+        bound, and a seat with no state-2 at all has nothing to carry
+        anyway; a GENESIS-CLIPPED window (lane younger than history)
+        resolves by the span leg alone, so a seat quiet since genesis
+        still gets its full K_A grace.
+
+    Deterministic under prune skew (a pure function of the
+    strictly-retained window every walker holds), skip-robust (our-side
+    outages can never un-exclude: a 23h outage bracketed by two bad
+    prints is not 24h of absence), and era-mint-robust (per-stamp
+    spacing -- no flap at cadence boundaries). ``no_price_streak`` is
+    the consecutive state-2 count in the same walk -- held by "sk" and
+    no-entry stamps, reset by state-1 -- and the walk continues past a
+    resolved verdict to state-1 or the cap for the count, so the streak
+    saturates at the window's stamp count and is identical whether the
+    lane is armed or dark (disclosure-only). Exclusion fires ONLY when
+    armed (attendance_eta > 0, rule R2); K_A is wall-time hours (rule
+    R3) snapped to whole lattice minutes exactly like
+    gpu_index.index.panel.carry_window_minutes. While dark the streak
+    still publishes and excluded is present-but-False.
+
+    Hours convert to minutes HERE, once -- the one seam."""
+    if not attendance_minted(dw_params):
+        return None
+    obs_stamp = int(obs_stamp)
+    half_life_minutes = float(dw_params["attendance_half_life_hours"]) * 60.0
+    exclusion_minutes = int(
+        round(float(dw_params["no_price_exclusion_hours"]) * 60.0)
+    )
+    armed = attendance_armed(dw_params)
+    history_minutes = int(dw_params["history_days"]) * 1440
+    if scheduled_window is None:
+        scheduled_window = schedule.scheduled_stamps(
+            obs_stamp - history_minutes, obs_stamp
+        )
+    # ONE decay table per observation: the window is shared by all
+    # sources, so w(s) is too. The exclusion walk shares the SAME window
+    # (the hard determinism cap), so its per-stamp era spacings -- each
+    # stamp's gap to its previous scheduled stamp -- are likewise
+    # computed once here: one prev_scheduled_stamp call for the window's
+    # oldest stamp (0 at genesis: no predecessor exists), plain
+    # differences inside.
+    decay = [
+        2.0 ** (-(obs_stamp - s) / half_life_minutes)
+        for s in scheduled_window
+    ]
+    spacings: List[int] = []
+    if scheduled_window:
+        before_window = schedule.prev_scheduled_stamp(scheduled_window[0])
+        last = before_window
+        for s in scheduled_window:
+            spacings.append(0 if last is None else int(s) - int(last))
+            last = s
+    # The exhausted-window leg's semantics split (docstring): a FULL
+    # history window ends in the dead-across-history verdict; a
+    # genesis-clipped one resolves by the span leg alone.
+    window_is_full = int(schedule.genesis_stamp) <= obs_stamp - history_minutes
+    prices = weight_state.get("prices") or {}
+    event_state = weight_state.get("events") or {}
+    out: Dict[str, Dict[str, Any]] = {}
+    for sid in sorted(set(str(s) for s in ids)):
+        series = prices.get(sid) or {}
+        events = event_state.get(sid) or {}
+        numerator = 0.0
+        denominator = 0.0
+        for s, w in zip(scheduled_window, decay):
+            if events.get(s) == EVENT_SKIP:
+                continue
+            denominator += w
+            if s in series:
+                numerator += w
+        factor = 1.0 if denominator == 0.0 else numerator / denominator
+        # The backward walk (docstring): skips consume nothing; the
+        # verdict LATCHES where the law resolves it, and the walk then
+        # continues to state-1 / the cap purely for the streak count
+        # (arm-independent disclosure).
+        streak = 0
+        nonskip_span = 0
+        state2_seen = False
+        state1_found = False
+        span_verdict = False
+        for i in range(len(scheduled_window) - 1, -1, -1):
+            s = scheduled_window[i]
+            if s in series:
+                state1_found = True
+                break
+            code = events.get(s)
+            if code == EVENT_SKIP:
+                continue  # our failure: consumes nothing, holds the run
+            nonskip_span += spacings[i]
+            if code == EVENT_NO_PRICE:
+                state2_seen = True
+                streak += 1
+            # no-entry: contributes span, holds the streak
+            if (
+                not span_verdict
+                and state2_seen
+                and nonskip_span >= exclusion_minutes
+            ):
+                span_verdict = True
+        # The verdict resolves at whichever comes FIRST walking backward:
+        # a latched span verdict stands even when a state-1 print sits
+        # deeper (the walk only continued past it for the streak count);
+        # the exhausted-window legs apply only when neither resolved.
+        excluded = span_verdict or (
+            not state1_found and state2_seen and window_is_full
+        )
+        out[sid] = {
+            "factor": factor,
+            "streak": streak,
+            "excluded": bool(armed and excluded),
+        }
+    return out
 
 
 def predictive_scores_obs(
@@ -1261,6 +1701,8 @@ def compute_panel_weights(
     dw_params: Dict[str, Any],
     fallback_weights: Dict[str, float],
     schedule: Any,
+    carrying: Sequence[str] = (),
+    attendance_view: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """One OBSERVATION's weight_calc block for the hourly panel lanes --
     the compute_dynamic_weights contract per observation, with the A2
@@ -1303,9 +1745,56 @@ def compute_panel_weights(
     hour-keyed lanes, THHMM on minute-keyed -- schedule.stamp_key). NO
     slot_prints key: every observation's own artifact records its
     trusted prints, replay ingests them per observation.
+
+    ATTENDANCE-WEIGHTING (METHODOLOGY.md section 8.6-8.7). On a lane
+    whose dw_params carry the minted knob triple this block additionally
+    computes the per-source attendance view (compute_attendance_view --
+    ONE decay table per observation, the same scheduled window as the
+    triple) and:
+
+      - publishes attendance_factor (9dp disclosure rounding; the
+        allocator eats FULL precision) / no_price_streak /
+        no_price_excluded on every sources row, over the WIDENED
+        publication domain scored UNION all members (fallback_weights'
+        keyspace: a seat absent longer than the history window still
+        publishes its exclusion state). Widening is
+        per-source-independent (a never-printed member scores None
+        everywhere), so the passer / quorum sets below, which read the
+        ORIGINAL scored list, are unchanged by it.
+      - when ARMED (attendance_eta > 0, rule R2) tilts the softmax by
+        eta*ln(A_i) and scales each seat's ceiling and floor with its
+        attendance (rules D4/D6/D7 -- see allocate_weights).
+
+    ``carrying`` -- the ARMED state-2 carry-casting seats (rule D4, the
+    caller's gate): the allocation domain extends to eligible UNION
+    carrying, so a quiet seat's re-cast vote fades under its own
+    (current) weight row; weights sum to 1 over the full voting set. The
+    A2 switch quorum still counts len(eligible) only -- carried seats
+    never help a lane latch dynamic. Non-empty carrying on a lane
+    without the minted knobs raises.
+
+    ``attendance_view`` -- an optional PRECOMPUTED compute_attendance_view
+    result (the scheduled_window amortization pattern):
+    compute_observation computes the one view per observation and
+    threads it here; it MUST be that function's output for the same
+    (pre-advance state, obs_stamp, dw_params) over ids covering every
+    published seat. None on minted lanes computes it internally (direct
+    callers/tests); passing one on a knob-less lane raises.
     """
     obs_stamp = int(obs_stamp)
     eligible = list(eligible)
+    carrying = [str(s) for s in carrying]
+    minted = attendance_minted(dw_params)
+    if carrying and not minted:
+        raise ValueError(
+            "carrying seats require the minted attendance knob triple -- "
+            "the armed D4 domain cannot extend on a knob-less lane"
+        )
+    if attendance_view is not None and not minted:
+        raise ValueError(
+            "attendance_view requires the minted attendance knob triple -- "
+            "a knob-less lane has no attendance law to publish under"
+        )
     history_minutes = int(dw_params["history_days"]) * 1440
     window_start = obs_stamp - history_minutes
     prices = weight_state.get("prices") or {}
@@ -1316,6 +1805,23 @@ def compute_panel_weights(
         if any(window_start <= t < obs_stamp for t in series)
     )
     scored = list(eligible) + [sid for sid in recent if sid not in eligible]
+    # Publication domain: on minted lanes every member (the
+    # fallback_weights keyspace) joins the published rows; knob-less
+    # lanes keep the scored set verbatim (byte parity).
+    published = scored + (
+        [sid for sid in sorted(fallback_weights) if sid not in scored]
+        if minted
+        else []
+    )
+    if attendance_view is None and minted:
+        attendance_view = compute_attendance_view(
+            weight_state,
+            published,
+            obs_stamp=obs_stamp,
+            schedule=schedule,
+            dw_params=dw_params,
+            scheduled_window=scheduled_window,
+        )
     attendance_by_sid = {
         sid: attendance(
             prices,
@@ -1325,7 +1831,7 @@ def compute_panel_weights(
             window_minutes=history_minutes,
             scheduled_window=scheduled_window,
         )
-        for sid in scored
+        for sid in published
     }
     attendance_floor = float(dw_params["attendance_floor"])
     passers = [
@@ -1336,7 +1842,7 @@ def compute_panel_weights(
     scores = predictive_scores_obs(
         weight_state,
         obs_stamp=obs_stamp,
-        source_ids=scored,
+        source_ids=published,
         dw_params=dw_params,
         schedule=schedule,
     )
@@ -1358,14 +1864,25 @@ def compute_panel_weights(
     stamp_iso = schedule.stamp_key(obs_stamp)
 
     flags: Dict[str, Any] = {"degenerate_allocation": None, "capped": []}
-    if not eligible:
+    # Rule D4: when armed, the allocation domain is eligible UNION the
+    # carry-casting state-2 seats -- a quiet seat's re-cast vote fades
+    # under a REAL (current) weight row instead of a frozen booked one.
+    # Empty carrying (every dark and knob-less lane) leaves the domain =
+    # eligible verbatim.
+    domain = eligible + [sid for sid in carrying if sid not in eligible]
+    eta = float(dw_params["attendance_eta"]) if minted else 0.0
+    armed = eta > 0
+    if not domain:
         weights: Dict[str, float] = {}
     elif mode == MODE_FALLBACK:
-        weights = {sid: float(fallback_weights[sid]) for sid in eligible}
+        # Fallback mode ignores eta entirely (config vector, byte-parity
+        # doctrine); an armed carrying seat still gets its config row --
+        # its re-cast vote needs a weight whichever mode the lane is in.
+        weights = {sid: float(fallback_weights[sid]) for sid in domain}
     else:
         q_values = {
             sid: (scores[sid]["Q"] if scores[sid]["Q"] is not None else 0.0)
-            for sid in eligible
+            for sid in domain
         }
         weights, flags = allocate_weights(
             q_values,
@@ -1373,6 +1890,21 @@ def compute_panel_weights(
             weight_min=float(dw_params["weight_min"]),
             weight_max=float(dw_params["weight_max"]),
             source_caps=dw_params.get("source_weight_caps") or {},
+            # Structural gate: the attendance inputs are NOT CONSTRUCTED
+            # unless armed -- eta 0 / knobs absent run the legacy
+            # allocator byte-identically (the kwargs are not even
+            # passed).
+            **(
+                {
+                    "attendance_factors": {
+                        sid: attendance_view[sid]["factor"]
+                        for sid in domain
+                    },
+                    "attendance_eta": eta,
+                }
+                if armed
+                else {}
+            ),
         )
     rounded = {sid: round(w, 6) for sid, w in weights.items()}
     for sid, w in rounded.items():
@@ -1401,6 +1933,26 @@ def compute_panel_weights(
                 "attendance_ratio": round(
                     float(attendance_by_sid[sid]["ratio"]), 9
                 ),
+                # Attendance-weighting fields, minted lanes only --
+                # beside the untouched attendance triple.
+                # attendance_factor is DISCLOSURE rounding (9dp, the q/Q
+                # rule); the allocator consumed full precision above.
+                # no_price_excluded is present-but-False while dark.
+                **(
+                    {
+                        "attendance_factor": round(
+                            float(attendance_view[sid]["factor"]), 9
+                        ),
+                        "no_price_streak": int(
+                            attendance_view[sid]["streak"]
+                        ),
+                        "no_price_excluded": bool(
+                            attendance_view[sid]["excluded"]
+                        ),
+                    }
+                    if attendance_view is not None
+                    else {}
+                ),
             }
             for sid in sorted(scores)
         },
@@ -1422,6 +1974,7 @@ def advance_panel_weight_state(
     vector: Optional[Dict[str, float]],
     mode: str,
     dw_params: Dict[str, Any],
+    events: Optional[Dict[str, str]] = None,
 ) -> None:
     """Advance the OBSERVATION-mode weight state with one published
     observation's pinned facts, then prune. ONE state machine for live
@@ -1439,6 +1992,13 @@ def advance_panel_weight_state(
         Empty/dark observations store NO vector, same as day mode.
       - mode: the block's pinned mode; the latch is monotonic (fallback
         -> dynamic, never back).
+      - events: this observation's np/sk attendance classifications
+        ({sid: code}, gpu_index.index.panel.attendance_events_for_stamp)
+        -- stored under weight_state["events"][sid][stamp] ONLY when the
+        lane's dw_params carry the minted attendance knob triple
+        (METHODOLOGY.md section 8.6: a knob-less lane's state must never
+        grow the key -- the D2 dark contract). Codes are fail-closed:
+        anything outside {"np", "sk"} raises.
 
     PRUNING (design section 5 perf): price and vector stamps STRICTLY
     older than obs_stamp - (history + max_forward + margin), all in
@@ -1469,11 +2029,17 @@ def advance_panel_weight_state(
     KEEPS MORE data, and everything below the strict threshold is never
     consulted by any computation (the proof above), so deferring the
     sweep is trivially score-neutral; the extra retention is bounded at
-    one day of stamps. The prices series' OTHER consumer, the dw vote
-    tail (dw_vote_tail in this module, ruling 2026-08-27), reads no
-    older than obs_stamp - the history window in minutes -- strictly
-    inside the kept range -- so the deferred sweep is vote-neutral as
-    well as score-neutral.
+    one day of stamps. The prices series' OTHER consumers -- the dw vote
+    tail (dw_vote_tail in this module, ruling 2026-08-27) and the
+    attendance A_i / streak reads (compute_attendance_view) -- read no
+    older than obs_stamp - the history window in minutes (A_i; the
+    bounded streak window is validated <= history at load), strictly
+    inside the kept range, so the deferred sweep is attendance-neutral
+    as well as vote- and score-neutral. The EVENTS series prunes in this
+    same sweep at the same threshold; a source whose prices prune empty
+    but still holds in-range events is deliberately NOT dropped from
+    events (a silent streak reset across a long absence would fake a
+    recovery).
     """
     obs_stamp = int(obs_stamp)
     history_minutes = int(dw_params["history_days"]) * 1440
@@ -1489,6 +2055,19 @@ def advance_panel_weight_state(
             f"PRUNE_MARGIN_MINUTES ({max_forward} + {PRUNE_MARGIN_MINUTES}); "
             f"pruning would eat live feature endpoints"
         )
+    attendance_lane = attendance_minted(dw_params)
+    if attendance_lane:
+        # Event codes validate BEFORE any mutation below: a mid-advance
+        # raise would leave the prints/vector/latch written and the
+        # events not -- a torn state no replay produces. The advance is
+        # all-or-nothing.
+        for sid in sorted(events or {}):
+            code = events[sid]
+            if code not in VALID_EVENT_CODES:
+                raise ValueError(
+                    f"unknown attendance event code {code!r} for {sid} at "
+                    f"stamp {obs_stamp}"
+                )
     prices = weight_state.setdefault("prices", {})
     for sid in sorted(prints or {}):
         entry = prints[sid]
@@ -1504,6 +2083,15 @@ def advance_panel_weight_state(
         weight_state["mode"] = MODE_DYNAMIC
     else:
         weight_state.setdefault("mode", MODE_FALLBACK)
+    if attendance_lane:
+        # Attendance events, conditional on the MINTED knob triple: a
+        # knob-less lane's state must never grow the key (the D2 dark
+        # contract). np/sk only; state-1 stays implicit in prices,
+        # no-entry implicit in absence from both. Codes were validated
+        # fail-closed in the pre-pass above (all-or-nothing).
+        event_state = weight_state.setdefault("events", {})
+        for sid in sorted(events or {}):
+            event_state.setdefault(sid, {})[obs_stamp] = events[sid]
     threshold = obs_stamp - (
         history_minutes + max_forward + PRUNE_MARGIN_MINUTES
     )
@@ -1517,6 +2105,13 @@ def advance_panel_weight_state(
             del series[stamp]
         if not series:
             del prices[sid]
+    event_series = weight_state.get("events") or {}
+    for sid in sorted(event_series):
+        series = event_series[sid]
+        for stamp in [t for t in series if t < threshold]:
+            del series[stamp]
+        if not series:
+            del event_series[sid]
     stale_vectors = sorted(t for t in vectors if t < threshold)
     for stamp in stale_vectors[:-1]:  # keep the newest as resolution anchor
         del vectors[stamp]

--- a/tests/live/test_attendance_live.py
+++ b/tests/live/test_attendance_live.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Computable
+"""LIVE seam: attendance weighting as the published record actually runs it.
+
+`./reproduce` recomputes each observation's index from its own receipts,
+consuming the published weights AS PUBLISHED -- so it verifies the
+aggregation and says nothing at all about how those weights were
+allocated. This file closes that gap from the other side: every input to
+the allocation is itself disclosed (`liveness_score` = Q_i,
+`attendance_factor` = A_i, and `calc_params.liveness` = gamma / eta /
+w_min / w_max), so the published weight vector can be RE-DERIVED from
+the public record and matched exactly against
+`gpu_index.index.weights.allocate_weights`.
+
+That makes this the acceptance check for the attendance port: it fails
+if the ported allocator and the producer disagree by one part in 1e-6 on
+any seat of any observation, on lanes where attendance is currently
+biting (a seat at A_i = 0.04 is pinned far below the 2.5% floor, and a
+seat past the hard cutoff carries no weight row at all).
+
+Like its sibling in this directory it refuses fixtures and refuses to
+record one: a self-recorded golden would freeze whatever this engine
+currently believes and re-assert it forever, which is the bug, not the
+check. Marked `live`, deselected by default, run with `pytest -m live`.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+
+import httpx
+import pytest
+
+from gpu_index.index.weights import allocate_weights
+from gpu_index.published.artifacts import day_key
+
+pytestmark = pytest.mark.live
+
+DEFAULT_PUBLIC_BASE_URL = "https://data.getcomputable.com"
+PUBLIC_BASE_URL = (
+    os.environ.get("GPU_INDEX_PUBLIC_BASE_URL") or DEFAULT_PUBLIC_BASE_URL
+)
+PUBLIC_SKUS = ("H100", "H200", "B300", "B200")
+LOOKBACK_DAYS = 7
+
+# The published receipt fields the attendance disclosure adds.
+ATTENDANCE_FIELDS = ("attendance_factor", "no_price_streak",
+                     "no_price_excluded")
+
+
+def _get_json(key: str):
+    response = httpx.get(
+        f"{PUBLIC_BASE_URL.rstrip('/')}/{key}", timeout=30.0,
+        follow_redirects=True,
+    )
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    return json.loads(response.content)
+
+
+@pytest.fixture(scope="module")
+def live_days():
+    """Newest published day per SKU as {sku: day document}."""
+    latest = _get_json("latest.json")
+    versions = {
+        entry["sku"]: entry["current_version"]
+        for entry in latest["data"]["versions"]
+    }
+    today = datetime.datetime.now(datetime.timezone.utc).date()
+    out = {}
+    for sku in PUBLIC_SKUS:
+        for back in range(0, LOOKBACK_DAYS + 1):
+            date = (today - datetime.timedelta(days=back)).isoformat()
+            document = _get_json(
+                day_key(date, sku=sku, version=versions[sku])
+            )
+            if document is not None and document["data"]["observations"]:
+                out[sku] = document
+                break
+        else:
+            pytest.fail(
+                f"the public front {PUBLIC_BASE_URL} served no {sku} "
+                f"observation day file in the last {LOOKBACK_DAYS} days"
+            )
+    return out
+
+
+def _attendance_observations(document):
+    """The day's observations whose params carry the attendance knobs."""
+    return [
+        observation
+        for observation in document["data"]["observations"]
+        if "attendance_eta" in (observation["calc_params"].get("liveness") or {})
+    ]
+
+
+@pytest.mark.parametrize("sku", PUBLIC_SKUS)
+def test_attendance_disclosure_rides_every_receipt(sku, live_days):
+    """The three per-source fields the methodology promises, on every
+    seat of every observation of a minted lane -- present, typed, and in
+    range. Their absence is the failure this catches: a disclosure that
+    quietly stops publishing looks exactly like a healthy panel."""
+    observations = _attendance_observations(live_days[sku])
+    if not observations:
+        pytest.skip(f"{sku}: the serving generation is not attendance-minted")
+    for observation in observations:
+        for receipt in observation["receipts"]:
+            where = f"{sku} {observation['observed_at']} {receipt['source_id']}"
+            for field in ATTENDANCE_FIELDS:
+                assert field in receipt, f"{where}: missing {field}"
+            factor = receipt["attendance_factor"]
+            assert isinstance(factor, (int, float)) and not isinstance(
+                factor, bool
+            ), f"{where}: attendance_factor {factor!r} is not a number"
+            assert 0.0 <= factor <= 1.0, f"{where}: A_i {factor} outside [0, 1]"
+            streak = receipt["no_price_streak"]
+            assert isinstance(streak, int) and not isinstance(streak, bool)
+            assert streak >= 0, f"{where}: negative no_price_streak {streak}"
+            assert isinstance(receipt["no_price_excluded"], bool)
+
+
+@pytest.mark.parametrize("sku", PUBLIC_SKUS)
+def test_published_weights_re_derive_from_the_published_inputs(sku, live_days):
+    """The port's acceptance check: softmax(gamma*Q + eta*ln A) with
+    attendance-scaled ceilings and collapsing floors, run over the
+    published Q and A under the published liveness params, must
+    reproduce every published weight EXACTLY at the published 6dp.
+
+    The domain is the seats carrying a weight row -- the producer's own
+    voting set, which is exactly what a hard-cutoff exclusion removes
+    (an excluded seat publishes weight null, and re-deriving it into the
+    softmax would be the wrong answer for the right-looking reason)."""
+    observations = _attendance_observations(live_days[sku])
+    if not observations:
+        pytest.skip(f"{sku}: the serving generation is not attendance-minted")
+    checked = 0
+    for observation in observations:
+        liveness = observation["calc_params"]["liveness"]
+        domain = {
+            receipt["source_id"]: receipt
+            for receipt in observation["receipts"]
+            if receipt.get("weight") is not None
+        }
+        if not domain:
+            continue  # a dark observation carries no vector to re-derive
+        scores = {
+            sid: (receipt["liveness_score"] or 0.0)
+            for sid, receipt in domain.items()
+        }
+        factors = {
+            sid: receipt["attendance_factor"]
+            for sid, receipt in domain.items()
+        }
+        weights, _ = allocate_weights(
+            scores,
+            gamma=float(liveness["gamma"]),
+            weight_min=float(liveness["weight_min"]),
+            weight_max=float(liveness["weight_max"]),
+            source_caps={},
+            attendance_factors=factors,
+            attendance_eta=float(liveness["attendance_eta"]),
+        )
+        for sid, receipt in domain.items():
+            assert round(weights[sid], 6) == receipt["weight"], (
+                f"{sku} {observation['observed_at']} {sid}: published weight "
+                f"{receipt['weight']} but re-derived {round(weights[sid], 6)} "
+                f"from Q={scores[sid]} A={factors[sid]} under "
+                f"gamma={liveness['gamma']} eta={liveness['attendance_eta']}"
+            )
+            checked += 1
+    assert checked, f"{sku}: no weight rows were re-derived"
+
+
+@pytest.mark.parametrize("sku", PUBLIC_SKUS)
+def test_an_excluded_seat_carries_no_weight_and_no_price(sku, live_days):
+    """The hard cutoff as the methodology states it: past the limit the
+    provider is out of the observation entirely -- no weight row, no
+    vote -- until it produces a usable price again."""
+    observations = _attendance_observations(live_days[sku])
+    if not observations:
+        pytest.skip(f"{sku}: the serving generation is not attendance-minted")
+    for observation in observations:
+        for receipt in observation["receipts"]:
+            if not receipt["no_price_excluded"]:
+                continue
+            where = f"{sku} {observation['observed_at']} {receipt['source_id']}"
+            assert receipt.get("weight") is None, (
+                f"{where}: excluded but published a weight row "
+                f"{receipt.get('weight')}"
+            )
+            assert receipt.get("price") is None, (
+                f"{where}: excluded but published a price {receipt.get('price')}"
+            )

--- a/tests/unit/test_attendance_weighting.py
+++ b/tests/unit/test_attendance_weighting.py
@@ -1,0 +1,577 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Computable
+"""Attendance weighting (METHODOLOGY.md sections 8.6-8.7).
+
+The three legs the methodology names, plus the contract that makes it
+safe to ship into a live series:
+
+  - **A_i**, the exponentially weighted attendance average over the
+    90-day window: our-side failures drop from BOTH sums (a provider is
+    never penalised for our outage), everything else absent counts 0
+    (the ramp-in rule), a genesis/all-skip window scores 1.0;
+  - **the hard cutoff**: past K_A wall-time hours without a usable
+    price the seat is excluded until it prints again -- resolved by a
+    backward walk in which our failures consume nothing, so an outage
+    can never manufacture (or erase) an exclusion, and per-stamp era
+    spacing keeps the verdict stable across a cadence change;
+  - **allocation**: softmax(gamma*Q + eta*ln A) with ceilings scaled by
+    A_i and floors collapsing with them, so a fading seat rides to
+    near-zero instead of hitting a second cliff.
+
+And the load-bearing safety property, pinned twice over: with the knobs
+ABSENT the engine is byte-identical to the pre-attendance one (the
+published series must not move because code landed), and at A_i = 1 for
+every seat the armed allocator reduces BIT-EXACTLY to the legacy body
+(so arming moves weights only where attendance actually differs).
+
+The classifier is pinned as ONE function serving both the live path and
+replay: every verdict is decided by published artifact bytes alone, or a
+replayed series would fork from the series that published it.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from gpu_index.index.panel import (
+    ATTENDANCE_KNOWN_STATUSES,
+    CARRY_BASIS_NO_PRICE,
+    attendance_events_for_stamp,
+    classify_attendance_source,
+)
+from gpu_index.index.panel_schedule import PanelSchedule
+from gpu_index.index.weights import (
+    EVENT_NO_PRICE,
+    EVENT_SKIP,
+    advance_panel_weight_state,
+    allocate_weights,
+    attendance_armed,
+    attendance_minted,
+    compute_attendance_view,
+    compute_panel_weights,
+    new_weight_state,
+    series_print,
+    validate_attendance_params,
+)
+
+HALF_LIFE_HOURS = 6.0
+EXCLUSION_HOURS = 24.0
+
+
+def _schedule(genesis="2026-08-01"):
+    return PanelSchedule(
+        genesis_date=genesis,
+        slot_grids=[{"from_date": genesis, "slot_hours_utc": list(range(24))}],
+    )
+
+
+def _dw(**overrides):
+    dw = {
+        "scheme": "predictive_v1",
+        "lookback_horizons_hours": [1, 2],
+        "forward_horizons_hours": [1, 2],
+        "history_days": 2,
+        "half_life_days": 1,
+        "ridge_lambda": 0.001,
+        "gamma": 4.0,
+        "weight_min": 0.025,
+        "weight_max": 0.30,
+        "min_train_samples": 3,
+        "target_variance_floor": 1e-12,
+        "switch_min_eligible": 3,
+        "max_abs_log_return": 0.5,
+        "source_weight_caps": {},
+        "attendance_floor": 0.5,
+    }
+    dw.update(overrides)
+    return dw
+
+
+def _minted(**overrides):
+    knobs = {
+        "attendance_half_life_hours": HALF_LIFE_HOURS,
+        "attendance_eta": 0.0,
+        "no_price_exclusion_hours": EXCLUSION_HOURS,
+    }
+    knobs.update(overrides)
+    return _dw(**knobs)
+
+
+def _armed(eta=0.5, **overrides):
+    return _minted(attendance_eta=eta, **overrides)
+
+
+def _state(prices=None, events=None):
+    state = new_weight_state()
+    for sid, stamps in (prices or {}).items():
+        state["prices"][sid] = {
+            int(t): series_print(1.0, (1.0, "USD")) for t in stamps
+        }
+    if events is not None:
+        state["events"] = {
+            sid: {int(t): code for t, code in series.items()}
+            for sid, series in events.items()
+        }
+    return state
+
+
+# ------------------------------------------------------------ the knobs
+
+
+def test_the_triple_rides_together_or_not_at_all():
+    assert validate_attendance_params(_dw()) is None
+    partial = _dw(attendance_eta=0.5)
+    with pytest.raises(ValueError, match="ride together"):
+        validate_attendance_params(partial)
+
+
+def test_bounds_are_wall_time_hours_inside_the_history_window():
+    history_hours = 2 * 24
+    ok = validate_attendance_params(
+        _dw(
+            attendance_half_life_hours=history_hours,
+            attendance_eta=0,
+            no_price_exclusion_hours=history_hours,
+        )
+    )
+    assert ok == {
+        "attendance_half_life_hours": float(history_hours),
+        "attendance_eta": 0.0,
+        "no_price_exclusion_hours": float(history_hours),
+    }
+    for bad in ({"attendance_half_life_hours": history_hours + 1},
+                {"no_price_exclusion_hours": 0},
+                {"attendance_eta": -1},
+                {"attendance_half_life_hours": True}):
+        params = _minted()
+        params.update(bad)
+        with pytest.raises(ValueError):
+            validate_attendance_params(params)
+
+
+def test_minted_and_armed_are_one_home_each():
+    assert not attendance_minted(_dw())
+    assert not attendance_armed(_dw())
+    assert attendance_minted(_minted())
+    assert not attendance_armed(_minted())  # eta 0: minted but dark
+    assert attendance_armed(_armed())
+
+
+# ------------------------------------------------- the section-3 classifier
+
+
+def test_classifier_reads_only_published_bytes():
+    # State 1 (implicit): a trusted print, including a sigma-fenced one --
+    # the fence holds a print out of the INDEX, never out of the record.
+    assert classify_attendance_source(
+        {"status": "ok", "chosen": {"usd_per_gpu_hr": 2.0},
+         "filter": {"accepted": True}}
+    ) is None
+    assert classify_attendance_source(
+        {"status": "ok", "chosen": {"usd_per_gpu_hr": 2.0},
+         "filter": {"accepted": False}}
+    ) is None
+    # State 2: read fine, nothing usable.
+    assert classify_attendance_source({"status": "ok"}) == EVENT_NO_PRICE
+    assert classify_attendance_source(
+        {"status": "ok", "chosen": {"usd_per_gpu_hr": 2.0},
+         "filter": {"untrusted_currency": True}}
+    ) == EVENT_NO_PRICE
+    assert classify_attendance_source({"status": "held_out"}) == EVENT_NO_PRICE
+    assert classify_attendance_source(
+        {"status": "uncorroborated_jump"}
+    ) == EVENT_NO_PRICE
+    # State 3: our failure.
+    assert classify_attendance_source({"status": "error"}) == EVENT_SKIP
+    assert classify_attendance_source({"status": "fx_unavailable"}) == EVENT_SKIP
+    assert classify_attendance_source(
+        {"status": "manually_excluded"}
+    ) == EVENT_SKIP
+    # No entry: implicit, never carried.
+    assert classify_attendance_source({"status": "missing"}) is None
+
+
+def test_carry_basis_is_the_replay_discriminator():
+    """The ONE byte that tells an armed no-price carry (the provider had
+    nothing) from a collection carry (we failed) on replay."""
+    assert classify_attendance_source(
+        {"status": "carried",
+         "carried": {"carry_basis": CARRY_BASIS_NO_PRICE}}
+    ) == EVENT_NO_PRICE
+    assert classify_attendance_source(
+        {"status": "carried", "carried": {"failure_kind": "fetch"}}
+    ) == EVENT_SKIP
+
+
+def test_an_unknown_status_fails_closed_to_skip():
+    """A vocabulary a later binary invents freezes A_i rather than
+    silently penalising the provider."""
+    assert "some_future_status" not in ATTENDANCE_KNOWN_STATUSES
+    assert classify_attendance_source(
+        {"status": "some_future_status"}
+    ) == EVENT_SKIP
+
+
+def test_a_lane_wide_outage_is_skip_for_every_seat():
+    """Precedence: our capture failed, so no provider is marked absent --
+    the per-source rows all read 'missing' and would otherwise count 0."""
+    rows = [{"source_id": "a", "status": "missing"},
+            {"source_id": "b", "status": "missing"}]
+    assert attendance_events_for_stamp(
+        rows, observation_missed=True, record_quarantined=None
+    ) == {"a": EVENT_SKIP, "b": EVENT_SKIP}
+    assert attendance_events_for_stamp(
+        rows, observation_missed=False, record_quarantined="poisoned"
+    ) == {"a": EVENT_SKIP, "b": EVENT_SKIP}
+    # Without the lane-wide flags the same rows are implicit no-entry.
+    assert attendance_events_for_stamp(
+        rows, observation_missed=False, record_quarantined=None
+    ) == {}
+
+
+# ------------------------------------------------------------ A_i itself
+
+
+def test_a_present_provider_scores_one_through_our_outages():
+    """The only reading under which our failures cost the provider
+    nothing: skip stamps leave BOTH sums."""
+    schedule = _schedule()
+    obs = schedule.genesis_stamp + 48 * 60
+    window = schedule.scheduled_stamps(obs - 2 * 1440, obs)
+    present, outage = window[:-3], window[-3:]
+    state = _state(
+        prices={"always": present},
+        events={"always": {t: EVENT_SKIP for t in outage}},
+    )
+    view = compute_attendance_view(
+        state, ["always"], obs_stamp=obs, schedule=schedule,
+        dw_params=_minted(),
+    )
+    assert view["always"]["factor"] == 1.0
+
+
+def test_absence_fades_at_the_declared_half_life():
+    """No prints at all inside the window: A_i = 0, and one print at
+    exactly one half-life back weighs half of one at the newest stamp."""
+    schedule = _schedule()
+    obs = schedule.genesis_stamp + 48 * 60
+    view = compute_attendance_view(
+        _state(prices={"quiet": []}), ["quiet"], obs_stamp=obs,
+        schedule=schedule, dw_params=_minted(),
+    )
+    assert view["quiet"]["factor"] == 0.0
+
+    window = schedule.scheduled_stamps(obs - 2 * 1440, obs)
+    decay_total = sum(
+        2.0 ** (-(obs - s) / (HALF_LIFE_HOURS * 60.0)) for s in window
+    )
+    one_stamp = window[-1]
+    view = compute_attendance_view(
+        _state(prices={"one": [one_stamp]}), ["one"], obs_stamp=obs,
+        schedule=schedule, dw_params=_minted(),
+    )
+    expected = (
+        2.0 ** (-(obs - one_stamp) / (HALF_LIFE_HOURS * 60.0)) / decay_total
+    )
+    assert view["one"]["factor"] == pytest.approx(expected, rel=1e-12)
+
+
+def test_a_genesis_window_scores_one_not_zero():
+    """Nothing scheduled means nothing missed -- the existing ratio's
+    convention, so a fresh lane never opens at A_i = 0."""
+    schedule = _schedule()
+    view = compute_attendance_view(
+        _state(), ["new"], obs_stamp=schedule.genesis_stamp,
+        schedule=schedule, dw_params=_minted(),
+    )
+    assert view["new"]["factor"] == 1.0
+
+
+def test_the_shared_decay_table_matches_a_naive_per_source_recompute():
+    """One decay table per observation is a perf shape, not a different
+    number: bit-identical to computing w(s) per source."""
+    schedule = _schedule()
+    obs = schedule.genesis_stamp + 48 * 60
+    window = schedule.scheduled_stamps(obs - 2 * 1440, obs)
+    prices = {"a": window[::2], "b": window[1::3], "c": window[-5:]}
+    events = {"b": {t: EVENT_SKIP for t in window[:4]}}
+    state = _state(prices=prices, events=events)
+    view = compute_attendance_view(
+        state, sorted(prices), obs_stamp=obs, schedule=schedule,
+        dw_params=_minted(),
+    )
+    for sid in prices:
+        num = den = 0.0
+        for s in window:
+            if events.get(sid, {}).get(s) == EVENT_SKIP:
+                continue
+            w = 2.0 ** (-(obs - s) / (HALF_LIFE_HOURS * 60.0))
+            den += w
+            if s in set(prices[sid]):
+                num += w
+        naive = 1.0 if den == 0.0 else num / den
+        assert view[sid]["factor"] == naive
+
+
+# ------------------------------------------------------- the hard cutoff
+
+
+def _quiet_state(schedule, obs, quiet_hours, *, skips=()):
+    window = schedule.scheduled_stamps(obs - 2 * 1440, obs)
+    quiet = [s for s in window if s >= obs - quiet_hours * 60]
+    printed = [s for s in window if s not in set(quiet)]
+    return _state(
+        prices={"seat": printed},
+        events={"seat": {
+            t: (EVENT_SKIP if t in set(skips) else EVENT_NO_PRICE)
+            for t in quiet
+        }},
+    ), quiet
+
+
+def test_exclusion_fires_past_the_cutoff_and_not_before():
+    schedule = _schedule()
+    obs = schedule.genesis_stamp + 48 * 60
+    for quiet_hours, expected in ((int(EXCLUSION_HOURS) - 1, False),
+                                  (int(EXCLUSION_HOURS) + 1, True)):
+        state, quiet = _quiet_state(schedule, obs, quiet_hours)
+        view = compute_attendance_view(
+            state, ["seat"], obs_stamp=obs, schedule=schedule,
+            dw_params=_armed(),
+        )
+        assert view["seat"]["excluded"] is expected
+        assert view["seat"]["streak"] == len(quiet)
+
+
+def test_our_outage_can_never_manufacture_an_exclusion():
+    """Skips consume nothing: a long our-side gap bracketed by a short
+    provider absence is not K_A hours of provider absence."""
+    schedule = _schedule()
+    obs = schedule.genesis_stamp + 48 * 60
+    window = schedule.scheduled_stamps(obs - 2 * 1440, obs)
+    quiet = [s for s in window if s >= obs - 30 * 60]
+    events = {t: EVENT_SKIP for t in quiet}
+    # Only the two newest stamps are genuine provider absence.
+    for t in quiet[-2:]:
+        events[t] = EVENT_NO_PRICE
+    state = _state(
+        prices={"seat": [s for s in window if s not in set(quiet)]},
+        events={"seat": events},
+    )
+    view = compute_attendance_view(
+        state, ["seat"], obs_stamp=obs, schedule=schedule, dw_params=_armed(),
+    )
+    assert view["seat"]["excluded"] is False
+    assert view["seat"]["streak"] == 2
+
+
+def test_exclusion_is_armed_only_but_the_streak_always_publishes():
+    """While dark the disclosure still rides every observation; only the
+    verdict waits for eta."""
+    schedule = _schedule()
+    obs = schedule.genesis_stamp + 48 * 60
+    state, quiet = _quiet_state(schedule, obs, int(EXCLUSION_HOURS) + 1)
+    dark = compute_attendance_view(
+        state, ["seat"], obs_stamp=obs, schedule=schedule, dw_params=_minted(),
+    )
+    armed = compute_attendance_view(
+        state, ["seat"], obs_stamp=obs, schedule=schedule, dw_params=_armed(),
+    )
+    assert dark["seat"]["excluded"] is False
+    assert armed["seat"]["excluded"] is True
+    assert dark["seat"]["streak"] == armed["seat"]["streak"] == len(quiet)
+
+
+def test_a_knob_less_lane_computes_no_view_at_all():
+    """The structural skip: not a zero, not a default -- nothing."""
+    schedule = _schedule()
+    assert compute_attendance_view(
+        _state(), ["seat"], obs_stamp=schedule.genesis_stamp + 60,
+        schedule=schedule, dw_params=_dw(),
+    ) is None
+
+
+# --------------------------------------------------------- the allocation
+
+
+def _scores(n=5):
+    return {f"s{i}": 0.05 * i for i in range(n)}
+
+
+def test_at_full_attendance_the_armed_allocator_is_bit_exact_legacy():
+    """Arming must move weights only where attendance actually differs;
+    every intermediate float has to reduce, not merely round the same."""
+    scores = _scores()
+    legacy, legacy_flags = allocate_weights(
+        scores, gamma=4.0, weight_min=0.025, weight_max=0.30, source_caps={},
+    )
+    armed, armed_flags = allocate_weights(
+        scores, gamma=4.0, weight_min=0.025, weight_max=0.30, source_caps={},
+        attendance_factors={sid: 1.0 for sid in scores}, attendance_eta=0.5,
+    )
+    assert armed == legacy
+    assert armed_flags == legacy_flags
+
+
+def test_eta_zero_never_reaches_the_armed_body():
+    scores = _scores()
+    legacy, _ = allocate_weights(
+        scores, gamma=4.0, weight_min=0.025, weight_max=0.30, source_caps={},
+    )
+    dark, _ = allocate_weights(
+        scores, gamma=4.0, weight_min=0.025, weight_max=0.30, source_caps={},
+        attendance_factors={sid: 0.1 for sid in scores}, attendance_eta=0.0,
+    )
+    assert dark == legacy
+
+
+def test_a_fading_seat_rides_below_the_floor_instead_of_off_a_cliff():
+    """The ceiling scales with A_i and the floor collapses with it, so a
+    seat at 4% attendance is capped at 4% of the ceiling -- below w_min,
+    which is the point (a second cliff at A ~ w_min/w_max is what the
+    collapsing floor exists to avoid)."""
+    scores = _scores()
+    factors = {sid: 1.0 for sid in scores}
+    factors["s0"] = 0.04
+    weights, _ = allocate_weights(
+        scores, gamma=4.0, weight_min=0.025, weight_max=0.30, source_caps={},
+        attendance_factors=factors, attendance_eta=0.5,
+    )
+    assert weights["s0"] == pytest.approx(0.30 * 0.04, rel=1e-12)
+    assert weights["s0"] < 0.025
+    assert sum(weights.values()) == pytest.approx(1.0, rel=1e-9)
+
+
+def test_a_zero_attendance_seat_never_reaches_the_log():
+    """ln(0) is never called; the seat keeps an explicit 0.0 row."""
+    scores = _scores()
+    factors = {sid: 1.0 for sid in scores}
+    factors["s0"] = 0.0
+    weights, _ = allocate_weights(
+        scores, gamma=4.0, weight_min=0.025, weight_max=0.30, source_caps={},
+        attendance_factors=factors, attendance_eta=0.5,
+    )
+    assert weights["s0"] == 0.0
+    assert sum(weights.values()) == pytest.approx(1.0, rel=1e-9)
+
+
+def test_ceilings_too_low_to_hold_the_mass_expand_proportionally():
+    """Panel-wide low attendance pins the allocation at the ceilings and
+    flags it, rather than publishing an infeasible vector."""
+    scores = _scores()
+    factors = {sid: 0.1 for sid in scores}  # cap mass 5 * 0.03 = 0.15
+    weights, flags = allocate_weights(
+        scores, gamma=4.0, weight_min=0.025, weight_max=0.30, source_caps={},
+        attendance_factors=factors, attendance_eta=0.5,
+    )
+    assert flags["degenerate_allocation"] == "cap_proportional"
+    assert weights == {sid: pytest.approx(1 / 5) for sid in scores}
+
+
+def test_every_seat_at_zero_attendance_publishes_uniform_not_a_divide():
+    scores = _scores()
+    weights, flags = allocate_weights(
+        scores, gamma=4.0, weight_min=0.025, weight_max=0.30, source_caps={},
+        attendance_factors={sid: 0.0 for sid in scores}, attendance_eta=0.5,
+    )
+    assert flags["degenerate_allocation"] == "uniform"
+    assert weights == {sid: pytest.approx(1 / 5) for sid in scores}
+
+
+def test_the_tilt_is_exactly_eta_log_a():
+    """The published formula, checked against a direct softmax rather
+    than the implementation's own arithmetic."""
+    # Attendance far enough above the fade that the scaled ceilings do
+    # not bind -- this pins the TILT, not the ceiling rule.
+    scores = {"a": 0.2, "b": 0.1}
+    factors = {"a": 0.8, "b": 1.0}
+    eta, gamma, w_min = 0.5, 4.0, 0.0
+    weights, _ = allocate_weights(
+        scores, gamma=gamma, weight_min=w_min, weight_max=1.0,
+        source_caps={}, attendance_factors=factors, attendance_eta=eta,
+    )
+    raw = {
+        sid: math.exp(gamma * scores[sid] + eta * math.log(factors[sid]))
+        for sid in scores
+    }
+    total = sum(raw.values())
+    for sid in scores:
+        assert weights[sid] == pytest.approx(raw[sid] / total, rel=1e-12)
+
+
+# ---------------------------------------------------- state and the block
+
+
+def test_a_knob_less_lane_never_grows_the_events_key():
+    """The dark contract at the state layer: no new bytes on a lane that
+    was not minted, even when events are handed in."""
+    state = new_weight_state()
+    advance_panel_weight_state(
+        state, obs_stamp=1440, prints={}, vector=None, mode="fallback",
+        dw_params=_dw(), events={"a": EVENT_NO_PRICE},
+    )
+    assert "events" not in state
+
+
+def test_a_minted_lane_records_and_prunes_events_with_prices():
+    state = new_weight_state()
+    advance_panel_weight_state(
+        state, obs_stamp=1440, prints={}, vector=None, mode="fallback",
+        dw_params=_minted(), events={"a": EVENT_NO_PRICE, "b": EVENT_SKIP},
+    )
+    assert state["events"] == {"a": {1440: EVENT_NO_PRICE},
+                               "b": {1440: EVENT_SKIP}}
+
+
+def test_an_unknown_event_code_raises_before_anything_is_written():
+    """All-or-nothing: a torn advance is a state no replay produces."""
+    state = new_weight_state()
+    with pytest.raises(ValueError, match="unknown attendance event code"):
+        advance_panel_weight_state(
+            state, obs_stamp=1440, prints={"a": series_print(1.0, (1.0, "USD"))},
+            vector={"a": 1.0}, mode="dynamic", dw_params=_minted(),
+            events={"a": "wat"},
+        )
+    assert state["prices"] == {}
+    assert state.get("mode", "fallback") == "fallback"
+
+
+def test_the_publication_domain_widens_to_every_member_when_minted():
+    """A seat absent longer than the history window still publishes its
+    exclusion state -- otherwise the disclosure disappears exactly when
+    it matters most."""
+    schedule = _schedule()
+    obs = schedule.genesis_stamp + 48 * 60
+    state = _state(prices={"printer": schedule.scheduled_stamps(
+        obs - 2 * 1440, obs)})
+    fallback = {"printer": 0.5, "ghost": 0.5}
+    block = compute_panel_weights(
+        state, obs_stamp=obs, eligible=["printer"], dw_params=_minted(),
+        fallback_weights=fallback, schedule=schedule,
+    )
+    assert set(block["sources"]) == {"printer", "ghost"}
+    for sid in fallback:
+        row = block["sources"][sid]
+        assert set(row) >= {
+            "attendance_factor", "no_price_streak", "no_price_excluded"
+        }
+    assert block["sources"]["ghost"]["attendance_factor"] == 0.0
+    # ... and a knob-less lane keeps the scored set verbatim.
+    bare = compute_panel_weights(
+        state, obs_stamp=obs, eligible=["printer"], dw_params=_dw(),
+        fallback_weights=fallback, schedule=schedule,
+    )
+    assert set(bare["sources"]) == {"printer"}
+    assert "attendance_factor" not in bare["sources"]["printer"]
+
+
+def test_carrying_seats_need_the_minted_knobs():
+    schedule = _schedule()
+    obs = schedule.genesis_stamp + 60
+    with pytest.raises(ValueError, match="carrying seats require"):
+        compute_panel_weights(
+            _state(), obs_stamp=obs, eligible=[], dw_params=_dw(),
+            fallback_weights={"a": 1.0}, schedule=schedule, carrying=["a"],
+        )

--- a/tests/unit/test_import_boundaries.py
+++ b/tests/unit/test_import_boundaries.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Computable
 """CI fence for the package dependency arrows (ARCHITECTURE.md):
-common <- observatory <- index <- published, plus exactly two declared
+common <- observatory <- index <- published, plus exactly three declared
 waivers. A new cross-package import fails here until it is either
-removed or documented as a third waiver in ARCHITECTURE.md."""
+removed or documented as a further waiver in ARCHITECTURE.md."""
 
 from __future__ import annotations
 
@@ -19,10 +19,13 @@ ALLOWED_EDGES = {
     ("published", "common"),
     ("published", "index"),
 }
-# The two declared waivers (ARCHITECTURE.md): file -> module prefixes.
+# The three declared waivers (ARCHITECTURE.md): file -> module prefixes.
 WAIVERS = {
     "observatory/sources/vast.py": ("gpu_index.index.composite", "gpu_index.index.sources"),
     "index/": ("gpu_index.observatory.catalog",),
+    # The carry-forward failure scope validates against the capture
+    # lane's ONE classification vocabulary (METHODOLOGY.md section 8.6).
+    "index/panel_config.py": ("gpu_index.observatory.collect",),
 }
 
 

--- a/tests/unit/test_minute_lattice.py
+++ b/tests/unit/test_minute_lattice.py
@@ -557,10 +557,19 @@ def test_period_boundary_minute_form_refused_on_hour_lane_at_parse():
     ) == date_hour_to_stamp("2026-08-01", 16)
 
 
-def test_minute_keyed_lane_refuses_without_live_lever(tmp_path, monkeypatch):
-    """PANEL_MINUTE_LANES_LIVE is the mechanical prerequisite gate: a
-    minute-keyed config validates offline (--check-config) but refuses
-    to RUN until the lever is set."""
+def test_minute_keyed_lane_refuses_without_live_lever(
+    tmp_path, monkeypatch, capsys
+):
+    """PANEL_MINUTE_LANES_LIVE is the mechanical prerequisite gate,
+    scoped to the hazard it names -- DUAL-PUBLISHING.
+
+    A minute-keyed config validates offline (--check-config), replays
+    read-only without any lever (--dry-run; --verify-published likewise,
+    returning before the fence), and refuses to PUBLISH until the lever
+    is set. The read-only modes write nothing, so there is no keyspace
+    for them to dual-publish into -- and refusing them would fence off
+    replaying the serving generation of a lane whose grid is
+    minute-keyed, which is the one thing this repository exists for."""
     import importlib.util
 
     spec = importlib.util.spec_from_file_location(
@@ -590,9 +599,33 @@ def test_minute_keyed_lane_refuses_without_live_lever(tmp_path, monkeypatch):
         ["compute_panel_index.py", "--config", str(cfg_path), "--check-config"],
     )
     assert mod.main() == 0
-    # A run refuses loudly before touching the bucket.
+    # A PUBLISHING run refuses loudly before touching the bucket.
     monkeypatch.setattr(
         "sys.argv",
         ["compute_panel_index.py", "--config", str(cfg_path), "--sync"],
     )
     assert mod.main() == 1
+    # ... and says so in terms of publishing, so an operator reading the
+    # refusal knows a read-only replay is available without the lever.
+    assert "PUBLISHING" in capsys.readouterr().out
+
+    # A READ-ONLY replay of the same lane runs with no lever at all. An
+    # empty record yields observation_missed artifacts and writes
+    # nothing -- the point is that the fence does not fire.
+    monkeypatch.setenv("GPU_INDEX_DATA_DIR", str(tmp_path / "empty-record"))
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "compute_panel_index.py",
+            "--config",
+            str(cfg_path),
+            "--observation",
+            "2026-09-01T0015",
+            "--dry-run",
+        ],
+    )
+    assert mod.main() == 0
+    assert "minute-keyed lane refused" not in capsys.readouterr().out
+    assert not (tmp_path / "empty-record").exists() or not list(
+        (tmp_path / "empty-record").rglob("*.json")
+    )

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -83,6 +83,9 @@ PUBLIC_NAMES = {
         "recently_printed", "series_print", "solve_linear",
         "dw_vote_tail", "source_return", "stamp_to_hour_iso",
         "validate_attendance_floor",
+        # Attendance weighting (METHODOLOGY.md sections 8.6-8.7).
+        "attendance_armed", "attendance_minted",
+        "compute_attendance_view", "validate_attendance_params",
     },
     "gpu_index.index.config": {
         "BasketConfigError", "load_basket_config", "sources_by_id",
@@ -148,6 +151,14 @@ PUBLIC_NAMES = {
         "stamp_to_hour_iso", "stamp_to_obs_key", "us_ca_verified_host",
         "vast_vwm_verified_us_ca_floor", "vast_vwm_verified_us_ca_v2",
         "vote_stddev", "weighted_composite", "window_incompatible",
+        # Carry-forward and attendance weighting (METHODOLOGY.md
+        # sections 8.6-8.7): the carry book, the shared stamp decoder it
+        # keys on, and the one attendance classifier both the live path
+        # and replay run.
+        "attendance_armed", "attendance_events_for_stamp",
+        "attendance_minted", "carry_prints_for", "carry_window_minutes",
+        "classify_attendance_source", "compute_attendance_view",
+        "obs_key_to_stamp", "update_carry_book",
     },
     "gpu_index.index.panel_config": {
         "PanelConfigError", "PanelSchedule", "PanelScheduleError",


### PR DESCRIPTION
Removes the walls between a clean clone and a replay of the currently serving generation. `./reproduce --lane <lane> 2026-09-01` runs the full pipeline on all four live lanes; `./reproduce <sku> 2026-09-01` stays green against the live record.

Supersedes #38 (the attendance-only scope), whose commits are the first two here.

## Wall 1 — the minute-keyed lane fence

Every live lane has been minute-keyed since 2026-08-29, so this fired on all four, before the engine was ever reached:

```
$ ./reproduce --lane h100_sxm 2026-09-01
ERROR: h100_sxm_v1_calc_v5: minute-keyed lane refused -- set
PANEL_MINUTE_LANES_LIVE=true only after the minute-grain ingest and the
replay-checkpoint follow-up are live
EXIT=1
```

The fence is kept, not deleted, and **scoped to the hazard it names — dual-publishing**. The two read-only modes cannot commit it: `--verify-published` already returned above the fence (a byte-for-byte recompute that writes nothing), and `--dry-run` derives observations and prints them, writing nothing either. Publishing still requires the lever, unchanged.

The pin was **updated, not removed**. The same test now pins both legs: a publishing run still refuses (and now says `PUBLISHING`, so an operator reading the refusal knows a read-only replay is available), and a read-only replay of the same minute-keyed lane runs with no lever and writes nothing.

```
$ ./reproduce --lane h100_sxm 2026-09-01   EXIT=0
$ ./reproduce --lane h200_sxm 2026-09-01   EXIT=0
$ ./reproduce --lane b300     2026-09-01   EXIT=0
$ ./reproduce --lane b200     2026-09-01   EXIT=0
```

With no local producer record the walk prints `PANEL_DARK [observation_missed]` per stamp and `observations written: 0` — the honest result, and the machinery is proven by the repo's own fixture and golden records (`test_panel_cli.py`, `test_panel_golden_artifact.py`, `test_minute_lattice.py`, all green).

## Wall 2 — attendance weighting (from #38)

The published record allocates on `softmax(γQ + η·ln A)` at `calc_params.liveness.attendance_eta = 0.5`, and the config gate refused the knobs outright. `METHODOLOGY.md` §8.6–8.7 already specify the behaviour; this implements it — the EWMA attendance factor, the hard cutoff, the state-2 carry, the η-tilted allocation with attendance-scaled ceilings and collapsing floors — plus the carry-forward machinery the armed path is defined in terms of.

The dark contract is load-bearing and golden-pinned: knobs absent → nothing new computed, no state key grown, engine byte-identical. At `A_i = 1` the armed allocator reduces bit-exactly to the legacy body.

**Verified against the live public record.** Every allocation input is itself published (`liveness_score` = Q, `attendance_factor` = A, `calc_params.liveness` = γ/η/bounds), so the published weight vector is re-derivable and matched — `tests/live/test_attendance_live.py`, which refuses to use or record a fixture:

```
$ pytest -m live        20 passed
re-derived from https://data.getcomputable.com, 2026-09-01:
  80 observations, 900 weight rows, 0 mismatches (H100 320, H200 240, B300 160, B200 180)
```

Not a null test — attendance is materially biting right now, and the legacy allocator mismatches all 16 H100 seats:

| lane | seat | A_i | streak | excluded | published weight |
|---|---|---|---|---|---|
| H200 | vast | 1.27e-07 | 422 | **yes** | `null` |
| H100 | vast | 0.042259815 | 46 | no | 0.012678 (below the 2.5% floor — the collapsing floor) |
| H100 | lium | 0.318669879 | 0 | no | 0.044452 |

## Minute-grain ingest parity

Verified code-for-code against the upstream lane, not just via the existing lattice test:

- `panel_schedule.py` — the era grid, minute stamps, `prev_scheduled_stamp`: **identical**; the only differences are docstring wording.
- `common/slots.py` — **zero code differences** (AST-compared with docstrings stripped).
- `common/store.py` — identical apart from import paths and the checkpoint accessors (see below).

One real defect found: the `slots.py` docstring still described the pre-rebase capture cadence ("fires every 30 minutes… the configured 2-4 slots") and omitted slot identity entirely, on the one file whose key grammar is a cross-repo contract. Corrected; the code was already right.

## Regression gate

```
$ ./reproduce h100 2026-09-01   22 MATCH, 0 MISMATCH, 0 degraded   EXIT=0
$ ./reproduce h200 2026-09-01   22 MATCH, 0 MISMATCH, 0 degraded   EXIT=0
$ ./reproduce b300 2026-09-01   22 MATCH, 0 MISMATCH, 0 degraded   EXIT=0
$ ./reproduce b200 2026-09-01   22 MATCH, 0 MISMATCH, 0 degraded   EXIT=0

$ pytest -q                      1556 passed
$ pytest -m live                 20 passed
$ ruff check src tests scripts   All checks passed
$ api_compat --against origin/main   no breaking changes
```

Exit codes read unpiped. No golden was hand-edited or re-recorded; the existing goldens pin the dark contract unchanged.

## Two upstream deltas deliberately NOT ported, with evidence

**The successor burst backfill.** It touches only a deploy manifest, a shell runner, and its test — **zero engine code**. It is an ops job that runs the same per-lane CLI with a larger publish valve during a mint ceremony. This repository has no deploy layer, and porting a deployment manifest would also carry internal topology into a public repo. Empirically it is not needed for the acceptance: the replay walk crosses the 2026-09-01T00:13:39Z succession boundary and completes.

**The replay checkpoint.** ~2,500 lines of producer-side machinery (module, store accessors, state serialize/restore/prune, CLI wiring, tests) whose entire purpose is to persist engine state into the private record bucket so the producer's steady-state walk stays bounded. This repository has no writer, and the public front serves no checkpoints, so the port would add an unexercisable write path. It is also not a blocker: the bounded replay runs green without it (453–485 in-window stamps per lane, ~0.1s wall). Happy to add it if you want the mirror complete rather than minimal — flagging rather than deciding unilaterally.

## Config sync — blocked upstream, needs a decision

`config/index_panel_*.json` still name the previous generation (`h100_sxm_v1_calc_v5`, `annex_a_v0_2_calc_v11`, `annex_a2_v0_3_calc_v10`) while the record serves `*_calc_v8` / `*_calc_v14`. Syncing them from upstream is not possible as specified:

- upstream's own baked configs are **two generations older still** (`annex_a_v0_2_calc_v8`, `h100_sxm_v1_calc_v2`) and carry neither the attendance knobs nor the carry pair — the live lanes are served from a registry, not from those files;
- the registry is not readable from here, and the public projection discloses the liveness block but **not** `carry_forward_window_hours` / `carry_forward_failure_kinds`, which armed attendance requires;
- the instruction was to sync from upstream and never hand-derive values, so I did not invent them.

Everything else is in place: a config carrying the serving generation's parameters validates and computes today.

```
$ python scripts/compute_panel_index.py --config <serving-shape> --check-config
NOTICE: config OK: panel h100_sxm methodology h100_sxm_v1_calc_v8; 16 members;
genesis 2026-08-23; 2 grid era(s); no bucket access performed
EXIT=0
```

## `ARCHITECTURE.md`

The carry-forward failure scope validates against the capture lane's own classification vocabulary rather than a second copy that would drift silently. That is a new `index → observatory` import, declared as a third waiver edge and enforced by `tests/unit/test_import_boundaries.py`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getcomputable/codesmith/gpu-index/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790832648&installation_model_id=433894&pr_number=39&repository=getcomputable%2Fgpu-index&return_to=https%3A%2F%2Fgithub.com%2Fgetcomputable%2Fgpu-index%2Fpull%2F39&signature=54f06c07f64e27d3d818c38cebc11faba76d276056ee58d710c7dea830dab624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->