### PR TITLE
feat: sync public lanes to attendance-weighted generation

### DIFF
--- a/config/index_panel_b200.json
+++ b/config/index_panel_b200.json
@@ -78,8 +78,8 @@
     }
   ],
   "calc": {
-    "methodology_id": "annex_a2_v0_3_calc_v10",
-    "description": "calc_v10 quarter-hour panel mint (annex_a2_v0_3_calc_v10); METHODOLOGY.md is the binding methodology document",
+    "methodology_id": "annex_a2_v0_3_calc_v14",
+    "description": "calc_v14 attendance-weighted quarter-hour panel mint (annex_a2_v0_3_calc_v14); METHODOLOGY.md is the binding methodology document",
     "availability_verified_sources": ["vast"],
     "min_sources_to_claim": 5,
     "eligible_tiers": [
@@ -94,6 +94,8 @@
     "iqm_alpha": 0.16666,
     "vote_sigma_source": "dw_history",
     "vote_sigma_floor_pct": 3.0,
+    "carry_forward_window_hours": 72,
+    "carry_forward_failure_kinds": ["fetch", "parse"],
     "manual_verify_pct": 15,
     "fx_lane": "none",
     "fx_max_staleness_days": 7,
@@ -132,7 +134,10 @@
       "target_variance_floor": 1e-12,
       "switch_min_eligible": 5,
       "max_abs_log_return": 0.5,
-      "attendance_floor": 0.5
+      "attendance_floor": 0.5,
+      "attendance_half_life_hours": 6,
+      "attendance_eta": 0.5,
+      "no_price_exclusion_hours": 24
     }
   },
   "members": [

--- a/config/index_panel_b300.json
+++ b/config/index_panel_b300.json
@@ -78,8 +78,8 @@
     }
   ],
   "calc": {
-    "methodology_id": "annex_a_v0_2_calc_v11",
-    "description": "calc_v11 quarter-hour panel mint (annex_a_v0_2_calc_v11); METHODOLOGY.md is the binding methodology document",
+    "methodology_id": "annex_a_v0_2_calc_v14",
+    "description": "calc_v14 attendance-weighted quarter-hour panel mint (annex_a_v0_2_calc_v14); METHODOLOGY.md is the binding methodology document",
     "availability_verified_sources": ["vast"],
     "min_sources_to_claim": 5,
     "eligible_tiers": [
@@ -94,6 +94,8 @@
     "iqm_alpha": 0.16666,
     "vote_sigma_source": "dw_history",
     "vote_sigma_floor_pct": 3.0,
+    "carry_forward_window_hours": 72,
+    "carry_forward_failure_kinds": ["fetch", "parse"],
     "manual_verify_pct": 15,
     "fx_lane": "ecb",
     "fx_max_staleness_days": 7,
@@ -147,7 +149,10 @@
       "target_variance_floor": 1e-12,
       "switch_min_eligible": 5,
       "max_abs_log_return": 0.5,
-      "attendance_floor": 0.5
+      "attendance_floor": 0.5,
+      "attendance_half_life_hours": 6,
+      "attendance_eta": 0.5,
+      "no_price_exclusion_hours": 24
     }
   },
   "members": [

--- a/config/index_panel_h100_sxm.json
+++ b/config/index_panel_h100_sxm.json
@@ -71,8 +71,8 @@
     "GH200"
   ],
   "calc": {
-    "methodology_id": "h100_sxm_v1_calc_v5",
-    "description": "calc_v5 quarter-hour panel mint (h100_sxm_v1_calc_v5); METHODOLOGY.md is the binding methodology document",
+    "methodology_id": "h100_sxm_v1_calc_v8",
+    "description": "calc_v8 attendance-weighted quarter-hour panel mint (h100_sxm_v1_calc_v8); METHODOLOGY.md is the binding methodology document",
     "availability_verified_sources": ["lium", "vast"],
     "min_sources_to_claim": 5,
     "eligible_tiers": [
@@ -87,6 +87,8 @@
     "iqm_alpha": 0.16666,
     "vote_sigma_source": "dw_history",
     "vote_sigma_floor_pct": 3.0,
+    "carry_forward_window_hours": 72,
+    "carry_forward_failure_kinds": ["fetch", "parse"],
     "manual_verify_pct": 15,
     "fx_lane": "ecb",
     "fx_max_staleness_days": 7,
@@ -129,7 +131,10 @@
       "target_variance_floor": 1e-12,
       "switch_min_eligible": 5,
       "max_abs_log_return": 0.5,
-      "attendance_floor": 0.5
+      "attendance_floor": 0.5,
+      "attendance_half_life_hours": 6,
+      "attendance_eta": 0.5,
+      "no_price_exclusion_hours": 24
     }
   },
   "members": [

--- a/config/index_panel_h200_sxm.json
+++ b/config/index_panel_h200_sxm.json
@@ -68,8 +68,8 @@
     "H20"
   ],
   "calc": {
-    "methodology_id": "h200_sxm_v1_calc_v5",
-    "description": "calc_v5 quarter-hour panel mint (h200_sxm_v1_calc_v5); METHODOLOGY.md is the binding methodology document",
+    "methodology_id": "h200_sxm_v1_calc_v8",
+    "description": "calc_v8 attendance-weighted quarter-hour panel mint (h200_sxm_v1_calc_v8); METHODOLOGY.md is the binding methodology document",
     "availability_verified_sources": [
       "lium",
       "vast"
@@ -87,6 +87,8 @@
     "iqm_alpha": 0.16666,
     "vote_sigma_source": "dw_history",
     "vote_sigma_floor_pct": 3.0,
+    "carry_forward_window_hours": 72,
+    "carry_forward_failure_kinds": ["fetch", "parse"],
     "manual_verify_pct": 15,
     "fx_lane": "none",
     "fx_max_staleness_days": 7,
@@ -129,7 +131,10 @@
       "target_variance_floor": 1e-12,
       "switch_min_eligible": 5,
       "max_abs_log_return": 0.5,
-      "attendance_floor": 0.5
+      "attendance_floor": 0.5,
+      "attendance_half_life_hours": 6,
+      "attendance_eta": 0.5,
+      "no_price_exclusion_hours": 24
     }
   },
   "members": [

--- a/scripts/compute_panel_index.py
+++ b/scripts/compute_panel_index.py
@@ -1037,6 +1037,7 @@ def main() -> int:
         # to protect a keyspace neither of them touches. Publishing
         # (--sync and every persisting target) still requires the lever,
         # unchanged and test-pinned.
+        # Replay checkpoints stay unmirrored: private-state writes have no public verifier.
         error(
             f"{methodology_id}: minute-keyed lane refused for PUBLISHING "
             f"-- set PANEL_MINUTE_LANES_LIVE=true only after the "

--- a/tests/unit/test_panel_configs.py
+++ b/tests/unit/test_panel_configs.py
@@ -51,7 +51,7 @@ NEUTRAL_EXCLUSION_REASON = (
 LANES = {
     "config/index_panel_b300.json": {
         "panel_id": "b300",
-        "methodology_id": "annex_a_v0_2_calc_v11",
+        "methodology_id": "annex_a_v0_2_calc_v14",
         "prefix": "index/b300_basket",
         "genesis": "2026-08-10",
         "claim_floor": 5,
@@ -63,7 +63,7 @@ LANES = {
     },
     "config/index_panel_b200.json": {
         "panel_id": "b200",
-        "methodology_id": "annex_a2_v0_3_calc_v10",
+        "methodology_id": "annex_a2_v0_3_calc_v14",
         "prefix": "index/b200_basket",
         "genesis": "2026-08-16",
         "claim_floor": 5,
@@ -75,7 +75,7 @@ LANES = {
     },
     "config/index_panel_h100_sxm.json": {
         "panel_id": "h100_sxm",
-        "methodology_id": "h100_sxm_v1_calc_v5",
+        "methodology_id": "h100_sxm_v1_calc_v8",
         "prefix": "index/h100_sxm",
         "genesis": "2026-08-23",
         "claim_floor": 5,
@@ -87,7 +87,7 @@ LANES = {
     },
     "config/index_panel_h200_sxm.json": {
         "panel_id": "h200_sxm",
-        "methodology_id": "h200_sxm_v1_calc_v5",
+        "methodology_id": "h200_sxm_v1_calc_v8",
         "prefix": "index/h200_sxm",
         "genesis": "2026-08-23",
         "claim_floor": 5,
@@ -260,6 +260,12 @@ def test_public_lane_configs_match_the_live_era3_calculation(configs):
         assert calc["iqm_alpha"] == 0.16666, rel
         assert calc["vote_sigma_source"] == "dw_history", rel
         assert calc["vote_sigma_floor_pct"] == 3.0, rel
+        assert calc["carry_forward_window_hours"] == 72, rel
+        assert calc["carry_forward_failure_kinds"] == ["fetch", "parse"], rel
+        dynamic = calc["dynamic_weights"]
+        assert dynamic["attendance_half_life_hours"] == 6, rel
+        assert dynamic["attendance_eta"] == 0.5, rel
+        assert dynamic["no_price_exclusion_hours"] == 24, rel
 
 
 def test_migrated_lanes_carry_daily_manual_exclusion_pairs_neutral_reasons(

--- a/tests/unit/test_panel_golden_artifact.py
+++ b/tests/unit/test_panel_golden_artifact.py
@@ -127,8 +127,16 @@ def _frozen_v6_config(tmp_path: Path) -> Path:
         "iqm_alpha",
         "vote_sigma_source",
         "vote_sigma_floor_pct",
+        "carry_forward_window_hours",
+        "carry_forward_failure_kinds",
     ):
         calc.pop(key)
+    for key in (
+        "attendance_half_life_hours",
+        "attendance_eta",
+        "no_price_exclusion_hours",
+    ):
+        calc["dynamic_weights"].pop(key)
     calc["filter_sigma_floor"] = 0.05
     path = tmp_path / "index_panel_b200_calc_v6.json"
     path.write_text(json.dumps(config, indent=2) + "\n")

--- a/tests/unit/test_panel_verify_published.py
+++ b/tests/unit/test_panel_verify_published.py
@@ -113,8 +113,16 @@ def _frozen_v6_config(tmp_path: Path) -> Path:
         "iqm_alpha",
         "vote_sigma_source",
         "vote_sigma_floor_pct",
+        "carry_forward_window_hours",
+        "carry_forward_failure_kinds",
     ):
         calc.pop(key)
+    for key in (
+        "attendance_half_life_hours",
+        "attendance_eta",
+        "no_price_exclusion_hours",
+    ):
+        calc["dynamic_weights"].pop(key)
     calc["filter_sigma_floor"] = 0.05
     path = tmp_path / "index_panel_b200_calc_v6.json"
     path.write_text(json.dumps(config, indent=2) + "\n")


### PR DESCRIPTION
## Summary

- update H100/H200 to calc_v8 and B300/B200 to calc_v14
- arm the disclosed attendance parameters: 6-hour half-life, eta 0.5, 24-hour no-price exclusion
- set carry forward to 72 hours for fetch and parse failures only
- pin the serving values in the shipped-config test

## Validation rails

All four configs pass the full offline loader. The carry keys are present as a pair; 72 hours is inside the validated (0, 168] range; fetch and parse are accepted failure-taxonomy members; timeout and budget are deliberately absent.

## Deliberate mirror gap

Producer replay checkpoints remain intentionally unmirrored. They persist private collection state, and this public verifier has no public path that can exercise that write behavior. A one-line marker at the minute-lane fence keeps a future re-sync from mistaking the omission for drift.

## Local checks

- tests/unit/test_panel_configs.py: 9 passed
- offline --check-config: all four public configs OK
- ruff on changed Python files: clean
- git diff --check: clean
- full pytest: 1,556 passed, 20 deselected

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getcomputable/codesmith/gpu-index/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790834703&installation_model_id=433894&pr_number=40&repository=getcomputable%2Fgpu-index&return_to=https%3A%2F%2Fgithub.com%2Fgetcomputable%2Fgpu-index%2Fpull%2F40&signature=7d29c6e2f17d09d40824388e3cc69cb07b37f248d9f3c699f8da1f9c4298734c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
