### PR TITLE
Reproduce full index from raw public history

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ inputs, and every published value live in the open.
 
 ## Reproduce a published value
 
-Every published value can be recomputed from its own receipts.
+Every published value can be re-derived end to end from the public record
+alone: the attendance factors, the liveness weights, the votes, and the value
+itself, never consuming a published intermediate.
 
 ```
 git clone https://github.com/getcomputable/gpu-index
@@ -59,32 +61,36 @@ pip install -e .
 install local; on systems that allow bare `pip install`, the venv lines are
 optional.)
 
-That reproduces the current UTC day: every H100 observation published so far,
-recomputed from the published per-provider receipts and matched against the
-published value, with every artifact digest verified. Exit 0 means every value
-and digest matched, 1 means a mismatch, and 2 means nothing could be verified.
-To check another accelerator or time, run
-`./reproduce <h100|h200|b300|b200> YYYY-MM-DD`; add `THH` to check one UTC hour.
+That re-derives the current UTC day from raw public history: attendance
+events and factors, liveness scores, the weight vector, the votes, and each
+observation's value, all computed from disclosed inputs and matched against
+the published record, with every artifact digest verified. It fetches the
+trailing history it needs, so a full day takes a few minutes. Exit 0 means
+every value and digest matched, 1 means a mismatch, and 2 means nothing could
+be verified. To check another accelerator or time, run
+`./reproduce <h100|h200|b300|b200> YYYY-MM-DD`; add `THH` to check one UTC
+hour. For the fast check that recomputes each value from its own published
+receipts only, run `./reproduce --receipts <sku> <date>`.
 
 A successful run looks like this, recorded live against
-https://data.getcomputable.com on 2026-08-31 at 18:31 UTC. The transcript is
-left exactly as recorded, with the repeated middle lines elided.
+https://data.getcomputable.com on 2026-09-01 at 07:29 UTC. The transcript is
+left exactly as recorded; the repeated middle lines and each observation's
+derived 16-source weight vector are elided.
 
 ```
 $ ./reproduce h100 "$(date -u +%F)"
-published record: H100/v4/observations/2026/08/31.json via public HTTPS front https://data.getcomputable.com
-digest OK: 2e406eef6a178179cd260c24a2d17706bad7280daa8e9e4b203710e14a532626
-H100 2026-08-31T00 recomputed 3.463378 (band 0.563078) published 3.463378 (band 0.563078) MATCH digest OK
-H100 2026-08-31T00:15 recomputed 3.463379 (band 0.563079) published 3.463379 (band 0.563079) MATCH digest OK
-[... 70 more MATCH lines ...]
-H100 2026-08-31T18 recomputed 3.530037 (band 0.519443) published 3.530037 (band 0.519443) MATCH digest OK
-H100 2026-08-31T18:15 recomputed 3.530067 (band 0.519526) published 3.530067 (band 0.519526) MATCH digest OK
-summary: 74 observation(s): 74 MATCH, 0 MISMATCH, 0 degraded
-[... non-fatal weight-window warning; the recompute-and-match above is unaffected ...]
+published record: full history via public HTTPS front https://data.getcomputable.com
+raw-only full reproduction: prices, dispersions, upstream status, carry basis, filter verdicts, timing, top-level flags, and calc_params are inputs; published derived intermediates are not
+H100 2026-09-01T00 derived 3.456577 (band 0.556277) published 3.456577 (band 0.556277) MATCH public digests OK
+H100 2026-09-01T00:15 derived 3.457619 (band 0.557319) published 3.457619 (band 0.557319) MATCH public digests OK
+[... 26 more MATCH lines, each followed by its derived weight vector ...]
+H100 2026-09-01T07 derived 3.465561 (band 0.565261) published 3.465561 (band 0.565261) MATCH public digests OK
+H100 2026-09-01T07:15 derived 3.465393 (band 0.565093) published 3.465393 (band 0.565093) MATCH public digests OK
+summary: 30 observation(s): 30 MATCH, 0 MISMATCH
 ```
 
-Run `./reproduce` with no arguments for the other modes, which replay a local
-collection record rather than the published one.
+Run `./reproduce --receipts` for the receipts-only value check; `--producer`
+and `--lane` replay a local collection record rather than the published one.
 
 ## What is here
 

--- a/reproduce
+++ b/reproduce
@@ -24,7 +24,8 @@
 # without verifying something; withheld sources degrade an observation
 # to digest-only with a distinct message.
 #
-# --full replays the full public calculation from raw disclosed inputs:
+# The default (and its explicit alias --full) replays the full public
+# calculation from raw disclosed inputs:
 # per-source prices and dispersions, status/timing facts, filter verdicts,
 # carried basis, and published calculation parameters. It derives the
 # attendance events and factors, liveness scores, weight vector, votes,
@@ -48,19 +49,23 @@ set -euo pipefail
 usage() {
   cat >&2 <<'EOF'
 usage: reproduce <h100|h200|b300|b200> <YYYY-MM-DD[THH]>
-       reproduce --full <sku> <YYYY-MM-DD[THH]>
+       reproduce --receipts <sku> <YYYY-MM-DD[THH]>
        reproduce --producer <sku> <YYYY-MM-DD[THH]>
        reproduce --lane <panel_id> <YYYY-MM-DD[THH]>
        reproduce --frozen <b300|b200> <YYYY-MM-DD>
 
-  <sku>             public SKU. Verifies the PUBLISHED record
-                    (recompute-and-match): a local copy under
-                    GPU_INDEX_DATA_DIR when it holds the requested day,
-                    else the public front (GPU_INDEX_PUBLIC_BASE_URL,
-                    default https://data.getcomputable.com). Exit 0
+  <sku>             public SKU. Re-derives the PUBLISHED record end to
+                    end from raw public history (attendance, liveness,
+                    weights, votes, IQM, and the index; --full is the
+                    same, kept as an alias) and matches every value.
+                    Reads a local copy under GPU_INDEX_DATA_DIR when it
+                    holds the requested day, else the public front
+                    (GPU_INDEX_PUBLIC_BASE_URL, default
+                    https://data.getcomputable.com). Fetches trailing
+                    history, so a day takes a few minutes. Exit 0
                     all-match, 1 mismatch/digest FAIL, 2 could not verify
-  --full            derive attendance, liveness, weights, votes, IQM,
-                    and the index from raw public history only
+  --receipts        the fast check: recompute each value from its own
+                    published receipts only (no weight re-derivation)
   --producer        force the internal producer-record replay/verify
   --lane <panel_id> run any configured panel lane, e.g. h100_broad or
                     h200_broad (configured lanes that are not public SKUs)
@@ -72,12 +77,17 @@ EOF
 
 MODE=sku
 PRODUCER=0
-FULL=0
+# Full re-derivation is the default for the sku mode; --receipts opts out
+# and --full stays as an explicit alias. FULL_EXPLICIT keeps the
+# cannot-combine guard for the other modes on explicit flags only.
+FULL=1
+FULL_EXPLICIT=0
 case "${1:-}" in
   --frozen) MODE=frozen; shift ;;
   --lane) MODE=lane; shift ;;
   --producer) PRODUCER=1; shift ;;
-  --full) FULL=1; shift ;;
+  --full) FULL=1; FULL_EXPLICIT=1; shift ;;
+  --receipts) FULL=0; shift ;;
   -h|--help) usage ;;
 esac
 
@@ -97,7 +107,7 @@ esac
 
 # ---------------------------------------------------------------- frozen
 # Legacy escape hatch: the retired daily-lane behavior, verbatim.
-if [ "$FULL" -eq 1 ] && [ "$MODE" != sku ]; then
+if [ "$FULL_EXPLICIT" -eq 1 ] && [ "$MODE" != sku ]; then
   echo "--full reads the PUBLISHED record; it does not combine with --lane or --frozen" >&2
   exit 2
 fi

--- a/reproduce
+++ b/reproduce
@@ -5,6 +5,7 @@
 # Reproduce PUBLISHED index observations.
 #
 #   ./reproduce <h100|h200|b300|b200> <YYYY-MM-DD[THH]>
+#   ./reproduce --full <sku>          <YYYY-MM-DD[THH]>
 #   ./reproduce --producer <sku>      <YYYY-MM-DD[THH]>
 #   ./reproduce --lane <panel_id>     <YYYY-MM-DD[THH]>
 #   ./reproduce --frozen <b300|b200>  <YYYY-MM-DD>
@@ -23,6 +24,13 @@
 # without verifying something; withheld sources degrade an observation
 # to digest-only with a distinct message.
 #
+# --full replays the full public calculation from raw disclosed inputs:
+# per-source prices and dispersions, status/timing facts, filter verdicts,
+# carried basis, and published calculation parameters. It derives the
+# attendance events and factors, liveness scores, weight vector, votes,
+# IQM, and final value without consuming any published derived
+# intermediate. Insufficient observable history is a typed refusal.
+#
 # Under --producer, the run replays a local collection record instead
 # (the panel engine, scripts/compute_panel_index.py;
 # h100 -> h100_sxm, h200 -> h200_sxm, b300, b200). There, an observation
@@ -40,6 +48,7 @@ set -euo pipefail
 usage() {
   cat >&2 <<'EOF'
 usage: reproduce <h100|h200|b300|b200> <YYYY-MM-DD[THH]>
+       reproduce --full <sku> <YYYY-MM-DD[THH]>
        reproduce --producer <sku> <YYYY-MM-DD[THH]>
        reproduce --lane <panel_id> <YYYY-MM-DD[THH]>
        reproduce --frozen <b300|b200> <YYYY-MM-DD>
@@ -50,6 +59,8 @@ usage: reproduce <h100|h200|b300|b200> <YYYY-MM-DD[THH]>
                     else the public front (GPU_INDEX_PUBLIC_BASE_URL,
                     default https://data.getcomputable.com). Exit 0
                     all-match, 1 mismatch/digest FAIL, 2 could not verify
+  --full            derive attendance, liveness, weights, votes, IQM,
+                    and the index from raw public history only
   --producer        force the internal producer-record replay/verify
   --lane <panel_id> run any configured panel lane, e.g. h100_broad or
                     h200_broad (configured lanes that are not public SKUs)
@@ -61,10 +72,12 @@ EOF
 
 MODE=sku
 PRODUCER=0
+FULL=0
 case "${1:-}" in
   --frozen) MODE=frozen; shift ;;
   --lane) MODE=lane; shift ;;
   --producer) PRODUCER=1; shift ;;
+  --full) FULL=1; shift ;;
   -h|--help) usage ;;
 esac
 
@@ -84,6 +97,11 @@ esac
 
 # ---------------------------------------------------------------- frozen
 # Legacy escape hatch: the retired daily-lane behavior, verbatim.
+if [ "$FULL" -eq 1 ] && [ "$MODE" != sku ]; then
+  echo "--full reads the PUBLISHED record; it does not combine with --lane or --frozen" >&2
+  exit 2
+fi
+
 if [ "$MODE" = frozen ]; then
   case "$ARG" in
     b300) CONFIG="config/index_basket.json" ;;
@@ -145,6 +163,10 @@ else
     fi
     if [ -z "${GPU_INDEX_PUBLIC_BASE_URL:-}" ] && [ ! -f "$DAY_FILE" ] && { [ -z "$VERSIONED_DAY_FILE" ] || [ ! -f "$VERSIONED_DAY_FILE" ]; }; then
       export GPU_INDEX_PUBLIC_BASE_URL="https://data.getcomputable.com"
+    fi
+    if [ "$FULL" -eq 1 ]; then
+      exec "$PY" "$ROOT/scripts/verify_published_record.py" \
+        --sku "$PUB_SKU" --date "$DATE" --full
     fi
     exec "$PY" "$ROOT/scripts/verify_published_record.py" \
       --sku "$PUB_SKU" --date "$DATE"

--- a/scripts/verify_published_record.py
+++ b/scripts/verify_published_record.py
@@ -22,6 +22,11 @@ and say so; they do not fail the run.
   verify_published_record.py --sku H100 --date 2026-08-22
   verify_published_record.py --sku B200 --date 2026-08-20T04
 
+``--full`` starts at the observable public-history origin and derives
+attendance events and factors, liveness scores, the weight vector, votes,
+IQM, and final index value from raw disclosed receipt fields. Published
+weights, liveness scores, attendance factors, and votes are never inputs.
+
 Exit codes: 0 every checked observation matched (digest OK; degraded
 observations are reported but do not fail), 1 any MISMATCH or digest
 FAIL, 2 could not verify (the record source is unreachable, no published
@@ -48,6 +53,11 @@ from gpu_index.common.bucket import BucketPublishError  # noqa: E402
 from gpu_index.published.artifacts import (  # noqa: E402
     ArtifactDigestError,
     PublishedRecordError,
+)
+from gpu_index.published.full import (  # noqa: E402
+    FullReproductionRefusal,
+    read_full_history,
+    reproduce_full_history,
 )
 from gpu_index.published.reader import PublishedRecordReader  # noqa: E402
 from gpu_index.published.verify import (  # noqa: E402
@@ -92,6 +102,77 @@ def _window_warning(reader, sku: str, date: str):
     )
 
 
+def _stamp_label(observed_at: str) -> str:
+    label = observed_at[:16]
+    # Preserve the historical hour-grain transcript while making
+    # quarter-hour observations distinguishable within an hour.
+    return label[:13] if label.endswith(":00") else label
+
+
+def _run_full(reader, *, sku: str, date: str, stamp: str | None) -> int:
+    print(
+        "raw-only full reproduction: prices, dispersions, upstream status, "
+        "carry basis, filter verdicts, timing, top-level flags, and "
+        "calc_params are inputs; published derived intermediates are not"
+    )
+    try:
+        history = read_full_history(reader, sku=sku, target_date=date)
+        run = reproduce_full_history(history, target_date=date)
+    except FullReproductionRefusal as exc:
+        print(f"FULL REFUSAL [{exc.code}]: {exc}", file=sys.stderr)
+        return 2
+    except ArtifactDigestError as exc:
+        print(f"digest FAIL: {exc}", file=sys.stderr)
+        return 1
+    except (httpx.HTTPError, BucketPublishError, OSError) as exc:
+        print(
+            f"could not verify: the published record is unreachable via "
+            f"{reader.describe()} ({exc})",
+            file=sys.stderr,
+        )
+        return 2
+    except PublishedRecordError as exc:
+        print(f"invalid published artifact: {exc}", file=sys.stderr)
+        return 1
+
+    checks = [
+        check
+        for check in run.checks
+        if stamp is None or check.observed_at.startswith(stamp)
+    ]
+    if not checks:
+        print(
+            f"FULL REFUSAL [target_not_observable]: no {sku} observation "
+            f"at {stamp or date}",
+            file=sys.stderr,
+        )
+        return 2
+
+    matched = mismatched = 0
+    for check in checks:
+        if check.verdict == VERDICT_MATCH:
+            matched += 1
+        else:
+            mismatched += 1
+        verdict = "MATCH" if check.verdict == VERDICT_MATCH else "MISMATCH"
+        print(
+            f"{check.sku} {_stamp_label(check.observed_at)} "
+            f"derived {_value_label(check.derived_value, check.derived_band)} "
+            f"published {_value_label(check.published_value, check.published_band)} "
+            f"{verdict} public digests OK"
+        )
+        weights = " ".join(
+            f"{source_id}={weight}"
+            for source_id, weight in sorted(check.derived_weights.items())
+        )
+        print(f"  weights: {weights or '(none)'}")
+    print(
+        f"summary: {len(checks)} observation(s): {matched} MATCH, "
+        f"{mismatched} MISMATCH"
+    )
+    return 1 if mismatched else 0
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
         description="verify published index observations "
@@ -106,6 +187,14 @@ def main(argv=None) -> int:
         "--date",
         required=True,
         help="YYYY-MM-DD (whole UTC day) or YYYY-MM-DDTHH (one observation)",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help=(
+            "derive attendance, liveness, weights, votes, IQM, and index "
+            "values from raw public history only"
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -128,6 +217,9 @@ def main(argv=None) -> int:
     except (PublishedRecordError, BucketPublishError) as exc:
         print(f"published record: {exc}", file=sys.stderr)
         return 2
+    if args.full:
+        print(f"published record: full history via {reader.describe()}")
+        return _run_full(reader, sku=sku, date=date, stamp=stamp)
     try:
         key = reader.resolve_day_key(date, sku=sku)
         print(f"published record: {key} via {reader.describe()}")
@@ -187,11 +279,7 @@ def main(argv=None) -> int:
         except PublishedRecordError as exc:
             print(f"invalid published observation: {exc}", file=sys.stderr)
             return 1
-        stamp_label = check.observed_at[:16]
-        if stamp_label.endswith(":00"):
-            # Preserve the historical hour-grain transcript while making
-            # quarter-hour observations distinguishable within an hour.
-            stamp_label = stamp_label[:13]
+        stamp_label = _stamp_label(check.observed_at)
         if check.verdict == VERDICT_DEGRADED:
             degraded += 1
             print(

--- a/scripts/verify_published_record.py
+++ b/scripts/verify_published_record.py
@@ -166,6 +166,18 @@ def _run_full(reader, *, sku: str, date: str, stamp: str | None) -> int:
             for source_id, weight in sorted(check.derived_weights.items())
         )
         print(f"  weights: {weights or '(none)'}")
+        if check.first_divergence is not None:
+            divergence = check.first_divergence
+            source = (
+                f" {divergence.source_id}"
+                if divergence.source_id is not None
+                else ""
+            )
+            print(
+                f"  FIRST DIVERGENCE: {check.observed_at}{source} "
+                f"{divergence.quantity} derived {divergence.derived!r} "
+                f"published {divergence.published!r}"
+            )
     print(
         f"summary: {len(checks)} observation(s): {matched} MATCH, "
         f"{mismatched} MISMATCH"

--- a/src/gpu_index/published/artifacts.py
+++ b/src/gpu_index/published/artifacts.py
@@ -63,6 +63,7 @@ _META_KEYS = frozenset(
         "disclosure_restatement_count",
     }
 )
+_SERIES_META_OPTIONAL_KEYS = frozenset({"window_basis_at"})
 # License block: the three fields the publisher actually emits. A
 # verifier must never need a licensing URL to check a price, so
 # ``commercial_licensing`` is tolerated-when-present, not required --
@@ -288,10 +289,23 @@ def _require_keys(
         )
 
 
-def _validate_meta(meta: Any, observations: List[Any]) -> None:
+def _validate_meta(
+    meta: Any, observations: List[Any], *, data_kind: str
+) -> None:
     if not isinstance(meta, dict):
         raise PublishedRecordError("envelope meta must be an object")
-    _require_keys(meta, _META_KEYS, "envelope meta")
+    _require_keys(
+        meta,
+        _META_KEYS,
+        "envelope meta",
+        optional=(
+            _SERIES_META_OPTIONAL_KEYS
+            if data_kind == "gpu_index_series"
+            else frozenset()
+        ),
+    )
+    if "window_basis_at" in meta:
+        _validate_effective_from(meta["window_basis_at"], "meta.window_basis_at")
     if meta["schema_version"] != 1:
         raise PublishedRecordError(
             f"unsupported meta.schema_version {meta['schema_version']!r} "
@@ -525,7 +539,9 @@ def decode_and_verify_artifact(raw: bytes) -> dict:
             "CC-BY-NC-4.0 pin"
         )
     observations = _validate_data(document["data"])
-    _validate_meta(document["meta"], observations)
+    _validate_meta(
+        document["meta"], observations, data_kind=document["data"]["kind"]
+    )
     payload = {
         key: document[key] for key in ("data", "meta", "license")
     }

--- a/src/gpu_index/published/full.py
+++ b/src/gpu_index/published/full.py
@@ -1,0 +1,491 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Computable
+"""Raw-only reproduction of the published weighting and index pipeline."""
+
+from __future__ import annotations
+
+import math
+from bisect import bisect_left
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+from gpu_index.index.panel import (
+    attendance_events_for_stamp,
+    median_stddev_composite,
+)
+from gpu_index.index.panel_schedule import obs_key_to_stamp, stamp_to_obs_key
+from gpu_index.index.weights import (
+    advance_panel_weight_state,
+    compute_attendance_view,
+    compute_panel_weights,
+    new_weight_state,
+)
+from gpu_index.published.artifacts import PublishedRecordError
+
+VERDICT_MATCH = "match"
+VERDICT_MISMATCH = "mismatch"
+FULL_HISTORY_BOUND_DAYS = 100
+
+
+class FullReproductionRefusal(PublishedRecordError):
+    """The public record does not expose enough raw history to derive."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class FullObservationCheck:
+    sku: str
+    observed_at: str
+    verdict: str
+    derived_value: Optional[float]
+    published_value: Optional[float]
+    derived_band: Optional[float]
+    published_band: Optional[float]
+    derived_weights: Dict[str, float]
+
+
+@dataclass(frozen=True)
+class FullReproduction:
+    checks: Tuple[FullObservationCheck, ...]
+
+
+class _ObservedSchedule:
+    """The exact public observation lattice, exposed as an engine schedule."""
+
+    def __init__(self, observations: Iterable[dict]) -> None:
+        keys = {
+            _stamp(observation): str(observation["observed_at"])[11:16]
+            for observation in observations
+        }
+        self._stamps = tuple(sorted(keys))
+        if not self._stamps:
+            raise FullReproductionRefusal(
+                "empty_history", "the public history contains no observations"
+            )
+        self._minute_keyed = any(label[3:] != "00" for label in keys.values())
+        self.genesis_stamp = self._stamps[0]
+
+    def scheduled_stamps(self, window_start: int, window_end: int) -> list[int]:
+        lo = bisect_left(self._stamps, int(window_start))
+        hi = bisect_left(self._stamps, int(window_end))
+        return list(self._stamps[lo:hi])
+
+    def prev_scheduled_stamp(self, stamp: int) -> Optional[int]:
+        index = bisect_left(self._stamps, int(stamp)) - 1
+        return None if index < 0 else self._stamps[index]
+
+    def stamp_key(self, stamp: int) -> str:
+        return stamp_to_obs_key(stamp, minute_keyed=self._minute_keyed)
+
+
+def _stamp(observation: dict) -> int:
+    observed_at = observation.get("observed_at")
+    if not isinstance(observed_at, str) or len(observed_at) < 16:
+        raise FullReproductionRefusal(
+            "invalid_observation_time",
+            f"an observation has no usable observed_at: {observed_at!r}",
+        )
+    return obs_key_to_stamp(observed_at[:16].replace(":", ""))
+
+
+def _is_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+def _dynamic_params(observation: dict) -> tuple[dict, Dict[str, float]]:
+    params = observation.get("calc_params")
+    if not isinstance(params, dict) or not isinstance(params.get("liveness"), dict):
+        raise FullReproductionRefusal(
+            "missing_liveness_params",
+            f"{observation.get('observed_at')}: calc_params.liveness is required",
+        )
+    members = params.get("members")
+    if not isinstance(members, list) or not members:
+        raise FullReproductionRefusal(
+            "missing_opening_weights",
+            f"{observation.get('observed_at')}: calc_params.members is required",
+        )
+    fallback = {
+        str(member["source_id"]): float(member["opening_weight"])
+        for member in members
+    }
+    dynamic = dict(params["liveness"])
+    dynamic["fallback_weights"] = fallback
+    dynamic["source_weight_caps"] = {}
+    return dynamic, fallback
+
+
+def _project_classifier_row(receipt: dict) -> dict:
+    if "upstream_status" not in receipt:
+        raise FullReproductionRefusal(
+            "missing_upstream_status",
+            f"receipt {receipt.get('source_id')!r} has no upstream_status",
+        )
+    upstream_status = receipt["upstream_status"]
+    detail: Dict[str, Any] = {
+        "source_id": receipt.get("source_id"),
+        "status": upstream_status,
+    }
+    if upstream_status == "ok" and receipt.get("price") is not None:
+        detail["chosen"] = {}
+        if receipt.get("filter_verdict") == "not_evaluated":
+            detail["filter"] = {"untrusted_currency": True}
+        else:
+            detail["filter"] = {}
+    if upstream_status == "carried":
+        detail["carried"] = {"carry_basis": receipt.get("carry_basis")}
+    return detail
+
+
+def public_attendance_events(observation: dict) -> Dict[str, str]:
+    """Port the engine classifier onto the public receipt vocabulary."""
+    rows = [_project_classifier_row(receipt) for receipt in observation["receipts"]]
+    reason = observation.get("reason")
+    return attendance_events_for_stamp(
+        rows,
+        observation_missed=(
+            bool(observation.get("observation_missed"))
+            or reason == "observation_missed"
+        ),
+        record_quarantined=(
+            observation.get("record_quarantined")
+            or (reason if reason == "record_quarantined" else None)
+        ),
+    )
+
+
+def _trusted_receipts(observation: dict, manual: set[str]) -> Dict[str, dict]:
+    trusted: Dict[str, dict] = {}
+    for receipt in observation["receipts"]:
+        source_id = str(receipt["source_id"])
+        if receipt.get("price_disclosure") == "withheld":
+            if receipt.get("upstream_status") in ("ok", "carried"):
+                raise FullReproductionRefusal(
+                    "withheld_price_history",
+                    f"{observation['observed_at']} {source_id}: the raw price "
+                    "history is withheld",
+                )
+            continue
+        if (
+            receipt.get("upstream_status") == "ok"
+            and receipt.get("carry_basis") is None
+            and receipt.get("filter_verdict") in ("accepted", "rejected")
+            and _is_number(receipt.get("price"))
+            and source_id not in manual
+        ):
+            trusted[source_id] = receipt
+    return trusted
+
+
+def public_weight_print(receipt: dict, *, observed_at: str) -> dict:
+    """Restore the engine's recorded-currency weight-series print."""
+    source_id = str(receipt.get("source_id"))
+    price = receipt.get("price")
+    currency = receipt.get("currency")
+    if not _is_number(price) or not isinstance(currency, str) or not currency:
+        raise FullReproductionRefusal(
+            "missing_weight_print_terms",
+            f"{observed_at} {source_id}: price and recorded currency are "
+            "required to derive the weight history",
+        )
+    fx_rate = receipt.get("fx_rate")
+    if fx_rate is None:
+        if currency != "USD":
+            raise FullReproductionRefusal(
+                "missing_weight_print_terms",
+                f"{observed_at} {source_id}: a non-USD weight-history "
+                "print requires its public FX rate",
+            )
+        native = float(price)
+    elif _is_number(fx_rate) and float(fx_rate) > 0:
+        native = round(float(price) / float(fx_rate), 6)
+    else:
+        raise FullReproductionRefusal(
+            "missing_weight_print_terms",
+            f"{observed_at} {source_id}: the public FX rate is not a "
+            "positive finite number",
+        )
+    return {
+        "usd": float(price),
+        "native": native,
+        "currency": currency,
+    }
+
+
+def read_full_history(reader: Any, *, sku: str, target_date: str) -> list[dict]:
+    """Read the contiguous public history required by the weighting engine.
+
+    The public 90-day series identifies the observable record origin. If a
+    day exists immediately before that rolling window, the lane is older and
+    the full 100-day disclosure bound is required. If it does not, the series
+    begins at the lane's public corpus origin and replay starts from the
+    engine's empty genesis state.
+    """
+    series = reader.read_series("90d", sku=sku)
+    from_observed_at = (series or {}).get("meta", {}).get("from_observed_at")
+    if not isinstance(from_observed_at, str) or len(from_observed_at) < 10:
+        raise FullReproductionRefusal(
+            "history_origin_unavailable",
+            "the public 90d series does not disclose from_observed_at; "
+            f"full reproduction needs the {FULL_HISTORY_BOUND_DAYS}-day "
+            "history bound or a public corpus origin",
+        )
+    try:
+        target = date.fromisoformat(target_date)
+        series_start = date.fromisoformat(from_observed_at[:10])
+    except ValueError as exc:
+        raise FullReproductionRefusal(
+            "invalid_history_date", f"the public history date is invalid: {exc}"
+        ) from exc
+    if series_start > target:
+        raise FullReproductionRefusal(
+            "target_not_observable",
+            f"the public 90d series begins at {series_start}, after {target}",
+        )
+
+    previous = reader.read_day((series_start - timedelta(days=1)).isoformat(), sku=sku)
+    if previous is None:
+        start = series_start
+        bound_label = f"public corpus origin {series_start.isoformat()}"
+    else:
+        start = target - timedelta(days=FULL_HISTORY_BOUND_DAYS - 1)
+        bound_label = (
+            f"{FULL_HISTORY_BOUND_DAYS}-day history bound beginning "
+            f"{start.isoformat()}"
+        )
+
+    observations = []
+    cursor = start
+    while cursor <= target:
+        day = cursor.isoformat()
+        envelope = previous if cursor == series_start - timedelta(days=1) else None
+        if envelope is None:
+            envelope = reader.read_day(day, sku=sku)
+        if envelope is None:
+            raise FullReproductionRefusal(
+                "insufficient_observable_history",
+                f"full reproduction requires a contiguous {bound_label}; "
+                f"published day {day} is unavailable",
+            )
+        rows = (envelope.get("data") or {}).get("observations")
+        if not isinstance(rows, list):
+            raise FullReproductionRefusal(
+                "invalid_history_day",
+                f"published day {day} has no observations array",
+            )
+        observations.extend(rows)
+        cursor += timedelta(days=1)
+
+    series_rows = (series.get("data") or {}).get("observations")
+    if not isinstance(series_rows, list):
+        raise FullReproductionRefusal(
+            "insufficient_observable_history",
+            "the public 90d series does not expose its observation lattice",
+        )
+    lower = series_start.isoformat()
+    upper = target.isoformat()
+    expected = sorted(
+        str(row.get("observed_at"))
+        for row in series_rows
+        if isinstance(row, dict)
+        and isinstance(row.get("observed_at"), str)
+        and lower <= str(row["observed_at"])[:10] <= upper
+    )
+    actual = sorted(
+        str(row.get("observed_at"))
+        for row in observations
+        if isinstance(row, dict)
+        and isinstance(row.get("observed_at"), str)
+        and lower <= str(row["observed_at"])[:10] <= upper
+    )
+    if actual != expected:
+        missing = sorted(set(expected) - set(actual))
+        extra = sorted(set(actual) - set(expected))
+        detail = []
+        if missing:
+            detail.append(f"missing {missing[0]}")
+        if extra:
+            detail.append(f"unexpected {extra[0]}")
+        raise FullReproductionRefusal(
+            "insufficient_observable_history",
+            "the public series/day observation lattice differs"
+            + (f" ({'; '.join(detail)})" if detail else ""),
+        )
+    return observations
+
+
+def reproduce_full_history(
+    observations: Iterable[dict], *, target_date: str
+) -> FullReproduction:
+    """Derive target-day weights, votes, IQM, and index from raw public rows."""
+    history = sorted(list(observations), key=_stamp)
+    schedule = _ObservedSchedule(history)
+    state = new_weight_state()
+    carry_book: Dict[str, dict] = {}
+    checks = []
+
+    for observation in history:
+        receipts = observation.get("receipts")
+        if not isinstance(receipts, list):
+            raise FullReproductionRefusal(
+                "missing_receipts",
+                f"{observation.get('observed_at')}: receipts are required",
+            )
+        events = public_attendance_events(observation)
+        params = observation["calc_params"]
+        dynamic, fallback = _dynamic_params(observation)
+        observation_date = str(observation["observed_at"])[:10]
+        manual = {
+            str(row["source_id"])
+            for row in params.get("manual_exclusions", [])
+            if row.get("date") == observation_date
+        }
+        trusted = _trusted_receipts(observation, manual)
+        obs_stamp = _stamp(observation)
+        attendance = compute_attendance_view(
+            state,
+            sorted(fallback),
+            obs_stamp=obs_stamp,
+            schedule=schedule,
+            dw_params=dynamic,
+        )
+        eligible = [
+            source_id
+            for source_id in sorted(trusted)
+            if not attendance[source_id]["excluded"]
+        ]
+        carrying = sorted(
+            str(receipt["source_id"])
+            for receipt in receipts
+            if receipt.get("upstream_status") == "carried"
+            and receipt.get("carry_basis") == "no_price"
+            and str(receipt["source_id"]) not in manual
+            and not attendance[str(receipt["source_id"])]["excluded"]
+        )
+        block = compute_panel_weights(
+            state,
+            obs_stamp=obs_stamp,
+            eligible=eligible,
+            dw_params=dynamic,
+            fallback_weights=fallback,
+            schedule=schedule,
+            carrying=carrying,
+            attendance_view=attendance,
+        )
+
+        passing = []
+        stddevs = {}
+        for receipt in receipts:
+            source_id = str(receipt["source_id"])
+            if receipt.get("filter_verdict") != "accepted":
+                continue
+            upstream_status = receipt.get("upstream_status")
+            if upstream_status == "carried":
+                carried = carry_book.get(source_id)
+                if carried is None:
+                    raise FullReproductionRefusal(
+                        "insufficient_carry_history",
+                        f"{observation['observed_at']} {source_id}: the public "
+                        "history has no prior accepted raw vote for this carry",
+                    )
+                price = carried["price"]
+                sd = carried["sd"]
+                weight = (
+                    block["weights"].get(source_id)
+                    if receipt.get("carry_basis") == "no_price"
+                    else carried["weight"]
+                )
+            elif upstream_status == "ok":
+                price = receipt.get("price")
+                sd = receipt.get("sd")
+                weight = block["weights"].get(source_id)
+            else:
+                continue
+            if weight is None or not _is_number(price):
+                continue
+            if not _is_number(sd):
+                raise FullReproductionRefusal(
+                    "missing_dispersion_history",
+                    f"{observation['observed_at']} {source_id}: a contributing "
+                    "raw dispersion value is unavailable",
+                )
+            passing.append((source_id, float(weight), float(price)))
+            stddevs[source_id] = float(sd)
+        composite = (
+            median_stddev_composite(
+                passing,
+                stddevs,
+                iqm_alpha=float(params.get("iqm_alpha", 0.0)),
+            )
+            if len(passing) >= int(params["min_sources_to_publish"])
+            else None
+        )
+        derived_value = None if composite is None else composite["value_usd_gpu_hr"]
+        derived_band = (
+            None if composite is None else composite["confidence_usd_gpu_hr"]
+        )
+        if observation_date == target_date:
+            published_value = observation.get("value_usd_gpu_hr")
+            published_band = observation.get("stability_band_usd_gpu_hr")
+            checks.append(
+                FullObservationCheck(
+                    sku=str(observation.get("sku", "")),
+                    observed_at=str(observation["observed_at"]),
+                    verdict=(
+                        VERDICT_MATCH
+                        if (derived_value, derived_band)
+                        == (published_value, published_band)
+                        else VERDICT_MISMATCH
+                    ),
+                    derived_value=derived_value,
+                    published_value=published_value,
+                    derived_band=derived_band,
+                    published_band=published_band,
+                    derived_weights=dict(block["weights"]),
+                )
+            )
+
+        for source_id, receipt in trusted.items():
+            if receipt.get("filter_verdict") != "accepted":
+                continue
+            weight = block["weights"].get(source_id)
+            sd = receipt.get("sd")
+            if weight is None or not _is_number(sd):
+                continue
+            carry_book[source_id] = {
+                "stamp": obs_stamp,
+                "price": float(receipt["price"]),
+                "sd": float(sd),
+                "weight": float(weight),
+            }
+
+        prints = {
+            source_id: public_weight_print(
+                receipt, observed_at=str(observation["observed_at"])
+            )
+            for source_id, receipt in trusted.items()
+        }
+        advance_panel_weight_state(
+            state,
+            obs_stamp=obs_stamp,
+            prints=prints,
+            vector=block["weights"],
+            mode=block["mode"],
+            dw_params=dynamic,
+            events=events,
+        )
+
+    if not checks:
+        raise FullReproductionRefusal(
+            "target_not_observable",
+            f"the public history contains no observation for {target_date}",
+        )
+    return FullReproduction(checks=tuple(checks))

--- a/src/gpu_index/published/full.py
+++ b/src/gpu_index/published/full.py
@@ -37,6 +37,14 @@ class FullReproductionRefusal(PublishedRecordError):
 
 
 @dataclass(frozen=True)
+class FullDivergence:
+    quantity: str
+    source_id: Optional[str]
+    derived: Any
+    published: Any
+
+
+@dataclass(frozen=True)
 class FullObservationCheck:
     sku: str
     observed_at: str
@@ -46,6 +54,7 @@ class FullObservationCheck:
     derived_band: Optional[float]
     published_band: Optional[float]
     derived_weights: Dict[str, float]
+    first_divergence: Optional[FullDivergence] = None
 
 
 @dataclass(frozen=True)
@@ -220,6 +229,41 @@ def public_weight_print(receipt: dict, *, observed_at: str) -> dict:
     }
 
 
+def _first_divergence(
+    receipts: list[dict],
+    block: dict,
+    derived_weights: Dict[str, float],
+    *,
+    derived_value: Optional[float],
+    published_value: Optional[float],
+    derived_band: Optional[float],
+    published_band: Optional[float],
+) -> Optional[FullDivergence]:
+    by_source = {str(receipt["source_id"]): receipt for receipt in receipts}
+    comparisons = (
+        ("attendance", "attendance_factor", "attendance_factor"),
+        ("score", "Q", "liveness_score"),
+    )
+    for quantity, derived_key, published_key in comparisons:
+        for source_id in sorted(by_source):
+            derived = (block["sources"].get(source_id) or {}).get(derived_key)
+            published = by_source[source_id].get(published_key)
+            if derived != published:
+                return FullDivergence(
+                    quantity, source_id, derived, published
+                )
+    for source_id in sorted(by_source):
+        derived = derived_weights.get(source_id)
+        published = by_source[source_id].get("weight")
+        if derived != published:
+            return FullDivergence("weight", source_id, derived, published)
+    derived = (derived_value, derived_band)
+    published = (published_value, published_band)
+    if derived != published:
+        return FullDivergence("value", None, derived, published)
+    return None
+
+
 def read_full_history(reader: Any, *, sku: str, target_date: str) -> list[dict]:
     """Read the contiguous public history required by the weighting engine.
 
@@ -381,6 +425,27 @@ def reproduce_full_history(
             attendance_view=attendance,
         )
 
+        derived_weights: Dict[str, float] = {}
+        for receipt in receipts:
+            source_id = str(receipt["source_id"])
+            if receipt.get("upstream_status") == "carried":
+                carried = carry_book.get(source_id)
+                if carried is None:
+                    raise FullReproductionRefusal(
+                        "insufficient_carry_history",
+                        f"{observation['observed_at']} {source_id}: the public "
+                        "history has no prior accepted raw vote for this carry",
+                    )
+                weight = (
+                    block["weights"].get(source_id)
+                    if receipt.get("carry_basis") == "no_price"
+                    else carried["weight"]
+                )
+            else:
+                weight = block["weights"].get(source_id)
+            if weight is not None:
+                derived_weights[source_id] = float(weight)
+
         passing = []
         stddevs = {}
         for receipt in receipts:
@@ -390,19 +455,10 @@ def reproduce_full_history(
             upstream_status = receipt.get("upstream_status")
             if upstream_status == "carried":
                 carried = carry_book.get(source_id)
-                if carried is None:
-                    raise FullReproductionRefusal(
-                        "insufficient_carry_history",
-                        f"{observation['observed_at']} {source_id}: the public "
-                        "history has no prior accepted raw vote for this carry",
-                    )
+                assert carried is not None
                 price = carried["price"]
                 sd = carried["sd"]
-                weight = (
-                    block["weights"].get(source_id)
-                    if receipt.get("carry_basis") == "no_price"
-                    else carried["weight"]
-                )
+                weight = derived_weights.get(source_id)
             elif upstream_status == "ok":
                 price = receipt.get("price")
                 sd = receipt.get("sd")
@@ -435,21 +491,30 @@ def reproduce_full_history(
         if observation_date == target_date:
             published_value = observation.get("value_usd_gpu_hr")
             published_band = observation.get("stability_band_usd_gpu_hr")
+            divergence = _first_divergence(
+                receipts,
+                block,
+                derived_weights,
+                derived_value=derived_value,
+                published_value=published_value,
+                derived_band=derived_band,
+                published_band=published_band,
+            )
             checks.append(
                 FullObservationCheck(
                     sku=str(observation.get("sku", "")),
                     observed_at=str(observation["observed_at"]),
                     verdict=(
                         VERDICT_MATCH
-                        if (derived_value, derived_band)
-                        == (published_value, published_band)
+                        if divergence is None
                         else VERDICT_MISMATCH
                     ),
                     derived_value=derived_value,
                     published_value=published_value,
                     derived_band=derived_band,
                     published_band=published_band,
-                    derived_weights=dict(block["weights"]),
+                    derived_weights=derived_weights,
+                    first_divergence=divergence,
                 )
             )
 

--- a/tests/live/test_full_reproduction_live.py
+++ b/tests/live/test_full_reproduction_live.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Computable
+"""LIVE acceptance for raw-only public-history reproduction."""
+
+from __future__ import annotations
+
+import datetime
+import os
+
+import pytest
+
+from gpu_index.common.bucket import BucketConfig
+from gpu_index.published.full import (
+    VERDICT_MATCH,
+    read_full_history,
+    reproduce_full_history,
+)
+from gpu_index.published.reader import PublishedRecordReader
+
+pytestmark = pytest.mark.live
+
+DEFAULT_PUBLIC_BASE_URL = "https://data.getcomputable.com"
+
+
+def test_current_h100_reproduces_from_raw_public_history_only():
+    public_url = (
+        os.environ.get("GPU_INDEX_PUBLIC_BASE_URL") or DEFAULT_PUBLIC_BASE_URL
+    )
+    reader = PublishedRecordReader(
+        BucketConfig.from_env({"GPU_INDEX_PUBLIC_BASE_URL": public_url})
+    )
+    today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+
+    history = read_full_history(reader, sku="H100", target_date=today)
+    run = reproduce_full_history(history, target_date=today)
+
+    assert run.checks, f"the public record has no H100 observations for {today}"
+    assert all(check.verdict == VERDICT_MATCH for check in run.checks)

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -44,6 +44,7 @@ PUBLIC_MODULES = {
     "gpu_index.index.weights",
     "gpu_index.published",
     "gpu_index.published.artifacts",
+    "gpu_index.published.full",
     "gpu_index.published.reader",
     "gpu_index.published.verify",
     "gpu_index.observatory",

--- a/tests/unit/test_published_canonical.py
+++ b/tests/unit/test_published_canonical.py
@@ -261,6 +261,15 @@ def test_unknown_license_key_refuses():
         decode_and_verify_artifact(_encode(_redigest(document)))
 
 
+def test_series_window_basis_timestamp_is_a_named_optional_meta_key():
+    document = json.loads(_load("series/24h.json"))
+    document["meta"]["window_basis_at"] = "2026-09-01T06:35:00.000Z"
+
+    envelope = decode_and_verify_artifact(_encode(_redigest(document)))
+
+    assert envelope["meta"]["window_basis_at"] == "2026-09-01T06:35:00.000Z"
+
+
 def test_latest_accepts_and_validates_version_pointer_metadata():
     document = json.loads(_load("latest.json"))
     document["data"]["versions"] = [

--- a/tests/unit/test_published_full.py
+++ b/tests/unit/test_published_full.py
@@ -79,9 +79,9 @@ def _observation():
                 "currency": "USD",
                 "fx_rate": None,
                 # Forbidden as derivation inputs. Deliberately nonsense.
-                "weight": 0.0,
-                "liveness_score": 999.0,
-                "attendance_factor": 0.0,
+                "weight": 0.2,
+                "liveness_score": None,
+                "attendance_factor": 1.0,
             }
             for i in range(5)
         ],
@@ -99,13 +99,18 @@ def test_full_reproduction_never_consumes_published_derived_intermediates():
         receipt["attendance_factor"] = index / 10
     second = reproduce_full_history([tampered], target_date="2026-09-01")
 
-    assert first == second
     assert len(first.checks) == 1
     check = first.checks[0]
     assert check.verdict == VERDICT_MATCH
     assert check.derived_value == 3.0
     assert check.derived_band == 1.1
     assert check.derived_weights == {f"s{i}": 0.2 for i in range(5)}
+    tampered_check = second.checks[0]
+    assert tampered_check.derived_value == check.derived_value
+    assert tampered_check.derived_band == check.derived_band
+    assert tampered_check.derived_weights == check.derived_weights
+    assert tampered_check.first_divergence.quantity == "attendance"
+    assert tampered_check.first_divergence.source_id == "s0"
 
 
 @pytest.mark.parametrize("carry_basis", ["no_price", None])
@@ -124,7 +129,7 @@ def test_full_reproduction_rebuilds_carried_votes_from_prior_raw_bytes(
             # them must not change a raw-only reconstruction.
             "price": 999.0,
             "sd": 999.0,
-            "weight": 999.0,
+            "weight": 0.2,
         }
     )
 
@@ -345,3 +350,11 @@ def test_full_cli_prints_derived_vector_and_value_match(monkeypatch, capsys):
     assert "MATCH" in output
     assert "weights: s0=0.2" in output
     assert "1 MATCH, 0 MISMATCH" in output
+
+    observation["receipts"][1]["weight"] = 999.0
+    assert cli.main() == 1
+    output = capsys.readouterr().out
+    assert (
+        "FIRST DIVERGENCE: 2026-09-01T00:00:00.000Z s1 weight "
+        "derived 0.2 published 999.0"
+    ) in output

--- a/tests/unit/test_published_full.py
+++ b/tests/unit/test_published_full.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Computable
+"""Raw-only full reproduction of published observations."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from gpu_index.index.weights import EVENT_NO_PRICE, EVENT_SKIP
+from gpu_index.published.full import (
+    FullReproductionRefusal,
+    VERDICT_MATCH,
+    public_attendance_events,
+    public_weight_print,
+    read_full_history,
+    reproduce_full_history,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _params():
+    return {
+        "aggregation": "median_ci_votes",
+        "iqm_alpha": 0.16666,
+        "min_sources_to_publish": 5,
+        "manual_exclusions": [],
+        "members": [
+            {"source_id": f"s{i}", "opening_weight": 0.2}
+            for i in range(5)
+        ],
+        "liveness": {
+            "scheme": "predictive_v1",
+            "lookback_horizons_hours": [1],
+            "forward_horizons_hours": [1],
+            "history_days": 1,
+            "half_life_days": 1,
+            "ridge_lambda": 1.0,
+            "gamma": 4.0,
+            "weight_min": 0.025,
+            "weight_max": 0.3,
+            "min_train_samples": 10,
+            "target_variance_floor": 1e-12,
+            "switch_min_eligible": 5,
+            "max_abs_log_return": 0.5,
+            "attendance_floor": 0.5,
+            "attendance_half_life_hours": 6,
+            "attendance_eta": 0.5,
+            "no_price_exclusion_hours": 24,
+        },
+    }
+
+
+def _observation():
+    return {
+        "kind": "gpu_price_index_observation",
+        "sku": "H100",
+        "methodology_id": "h100_sxm_v1_calc_v8",
+        "observed_at": "2026-09-01T00:00:00.000Z",
+        "status": "ok",
+        "reason": None,
+        "calc_params": _params(),
+        "value_usd_gpu_hr": 3.0,
+        "stability_band_usd_gpu_hr": 1.1,
+        "receipts": [
+            {
+                "source_id": f"s{i}",
+                "upstream_status": "ok",
+                "carry_basis": None,
+                "filter_verdict": "accepted",
+                "price_disclosure": "published",
+                "price": float(i + 1),
+                "sd": 0.1,
+                "currency": "USD",
+                "fx_rate": None,
+                # Forbidden as derivation inputs. Deliberately nonsense.
+                "weight": 0.0,
+                "liveness_score": 999.0,
+                "attendance_factor": 0.0,
+            }
+            for i in range(5)
+        ],
+    }
+
+
+def test_full_reproduction_never_consumes_published_derived_intermediates():
+    observation = _observation()
+    first = reproduce_full_history([observation], target_date="2026-09-01")
+
+    tampered = copy.deepcopy(observation)
+    for index, receipt in enumerate(tampered["receipts"]):
+        receipt["weight"] = 10_000 + index
+        receipt["liveness_score"] = -10_000 - index
+        receipt["attendance_factor"] = index / 10
+    second = reproduce_full_history([tampered], target_date="2026-09-01")
+
+    assert first == second
+    assert len(first.checks) == 1
+    check = first.checks[0]
+    assert check.verdict == VERDICT_MATCH
+    assert check.derived_value == 3.0
+    assert check.derived_band == 1.1
+    assert check.derived_weights == {f"s{i}": 0.2 for i in range(5)}
+
+
+@pytest.mark.parametrize("carry_basis", ["no_price", None])
+def test_full_reproduction_rebuilds_carried_votes_from_prior_raw_bytes(
+    carry_basis,
+):
+    first = _observation()
+    second = copy.deepcopy(first)
+    second["observed_at"] = "2026-09-01T00:15:00.000Z"
+    carried = second["receipts"][2]
+    carried.update(
+        {
+            "upstream_status": "carried",
+            "carry_basis": carry_basis,
+            # Published carry outputs are derived intermediates. Corrupting
+            # them must not change a raw-only reconstruction.
+            "price": 999.0,
+            "sd": 999.0,
+            "weight": 999.0,
+        }
+    )
+
+    result = reproduce_full_history(
+        [first, second], target_date="2026-09-01"
+    )
+
+    assert [check.verdict for check in result.checks] == [
+        VERDICT_MATCH,
+        VERDICT_MATCH,
+    ]
+    assert result.checks[1].derived_value == 3.0
+    assert result.checks[1].derived_band == 1.1
+
+
+def test_public_attendance_classifier_preserves_the_engine_event_table():
+    observation = _observation()
+    observation["receipts"] = [
+        {
+            "source_id": "present_but_filtered",
+            "upstream_status": "ok",
+            "price": 1.0,
+            "filter_verdict": "rejected",
+        },
+        {
+            "source_id": "no_usable_price",
+            "upstream_status": "ok",
+            "price": None,
+            "filter_verdict": "not_evaluated",
+        },
+        {
+            "source_id": "provider_carry",
+            "upstream_status": "carried",
+            "carry_basis": "no_price",
+        },
+        {
+            "source_id": "collector_carry",
+            "upstream_status": "carried",
+            "carry_basis": None,
+        },
+        {
+            "source_id": "collector_error",
+            "upstream_status": "error",
+        },
+        {
+            "source_id": "ramp_in",
+            "upstream_status": "missing",
+        },
+    ]
+
+    assert public_attendance_events(observation) == {
+        "no_usable_price": EVENT_NO_PRICE,
+        "provider_carry": EVENT_NO_PRICE,
+        "collector_carry": EVENT_SKIP,
+        "collector_error": EVENT_SKIP,
+    }
+
+
+def test_public_top_level_outage_flag_skips_every_seat():
+    observation = _observation()
+    observation["reason"] = "observation_missed"
+
+    assert public_attendance_events(observation) == {
+        f"s{i}": EVENT_SKIP for i in range(5)
+    }
+
+
+def test_public_weight_print_restores_recorded_currency_terms():
+    assert public_weight_print(
+        {
+            "source_id": "eu-cloud",
+            "price": 2.3286,
+            "currency": "EUR",
+            "fx_rate": 1.1643,
+        },
+        observed_at="2026-09-01T00:00:00.000Z",
+    ) == {"usd": 2.3286, "native": 2.0, "currency": "EUR"}
+    assert public_weight_print(
+        {
+            "source_id": "rounded-eu-cloud",
+            "price": 3.686523,
+            "currency": "EUR",
+            "fx_rate": 1.1643,
+        },
+        observed_at="2026-09-01T00:00:00.000Z",
+    )["native"] == 3.1663
+
+
+def test_full_reproduction_typed_refusal_names_missing_status_history():
+    observation = _observation()
+    del observation["receipts"][2]["upstream_status"]
+
+    with pytest.raises(FullReproductionRefusal) as caught:
+        reproduce_full_history([observation], target_date="2026-09-01")
+
+    assert caught.value.code == "missing_upstream_status"
+    assert "s2" in str(caught.value)
+
+
+def test_history_loader_uses_the_public_series_origin_and_verified_days():
+    observation = _observation()
+
+    class Reader:
+        def read_series(self, _range, *, sku):
+            assert (_range, sku) == ("90d", "H100")
+            return {
+                "meta": {"from_observed_at": observation["observed_at"]},
+                "data": {
+                    "observations": [
+                        {"observed_at": observation["observed_at"]}
+                    ]
+                },
+            }
+
+        def read_day(self, date, *, sku):
+            assert sku == "H100"
+            if date == "2026-08-31":
+                return None
+            if date == "2026-09-01":
+                return {"data": {"observations": [observation]}}
+            raise AssertionError(f"unexpected day read {date}")
+
+    history = read_full_history(Reader(), sku="H100", target_date="2026-09-01")
+
+    assert history == [observation]
+
+
+def test_history_loader_typed_refusal_names_the_missing_bound():
+    class Reader:
+        def read_series(self, _range, *, sku):
+            return {"meta": {"from_observed_at": "2026-08-31T00:00:00.000Z"}}
+
+        def read_day(self, date, *, sku):
+            return None
+
+    with pytest.raises(FullReproductionRefusal) as caught:
+        read_full_history(Reader(), sku="H100", target_date="2026-09-01")
+
+    assert caught.value.code == "insufficient_observable_history"
+    assert "public corpus origin 2026-08-31" in str(caught.value)
+    assert "published day 2026-08-31 is unavailable" in str(caught.value)
+
+
+def test_history_loader_refuses_when_series_and_day_lattices_disagree():
+    observation = _observation()
+
+    class Reader:
+        def read_series(self, _range, *, sku):
+            return {
+                "meta": {"from_observed_at": observation["observed_at"]},
+                "data": {
+                    "observations": [
+                        {"observed_at": observation["observed_at"]},
+                        {"observed_at": "2026-09-01T00:15:00.000Z"},
+                    ]
+                },
+            }
+
+        def read_day(self, date, *, sku):
+            if date == "2026-08-31":
+                return None
+            return {"data": {"observations": [observation]}}
+
+    with pytest.raises(FullReproductionRefusal) as caught:
+        read_full_history(Reader(), sku="H100", target_date="2026-09-01")
+
+    assert caught.value.code == "insufficient_observable_history"
+    assert "series/day observation lattice differs" in str(caught.value)
+
+
+def test_full_cli_prints_derived_vector_and_value_match(monkeypatch, capsys):
+    observation = _observation()
+
+    class Reader:
+        def describe(self):
+            return "test public record"
+
+        def read_series(self, _range, *, sku):
+            return {
+                "meta": {"from_observed_at": observation["observed_at"]},
+                "data": {
+                    "observations": [
+                        {"observed_at": observation["observed_at"]}
+                    ]
+                },
+            }
+
+        def read_day(self, date, *, sku):
+            if date == "2026-08-31":
+                return None
+            return {"data": {"observations": [observation]}}
+
+    spec = importlib.util.spec_from_file_location(
+        "verify_published_record_full_test",
+        REPO_ROOT / "scripts" / "verify_published_record.py",
+    )
+    cli = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cli)
+    monkeypatch.setattr(cli, "PublishedRecordReader", Reader)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_published_record.py",
+            "--sku",
+            "H100",
+            "--date",
+            "2026-09-01",
+            "--full",
+        ],
+    )
+
+    assert cli.main() == 0
+    output = capsys.readouterr().out
+    assert "raw-only full reproduction" in output
+    assert "derived 3.0" in output
+    assert "published 3.0" in output
+    assert "MATCH" in output
+    assert "weights: s0=0.2" in output
+    assert "1 MATCH, 0 MISMATCH" in output

--- a/tests/unit/test_reproduce_routing.py
+++ b/tests/unit/test_reproduce_routing.py
@@ -185,6 +185,16 @@ def test_public_base_url_routes_to_the_published_verifier(shim, data_dir):
     assert _shim_env(result) == "https://record.example.com/cgi"
 
 
+def test_full_mode_routes_to_the_raw_only_public_derivation(shim, data_dir):
+    result = _run(shim, data_dir, "--full", "h100", "2026-09-01")
+
+    assert result.returncode == 0, result.stderr
+    (line,) = _shim_lines(result)
+    assert "verify_published_record.py" in line
+    assert "--sku H100 --date 2026-09-01 --full" in line
+    assert _shim_env(result) == "https://data.getcomputable.com"
+
+
 def test_producer_flag_forces_the_internal_replay(shim, data_dir):
     # Even with a published day file present, --producer keeps the
     # previous producer-record semantics verbatim.

--- a/tests/unit/test_reproduce_routing.py
+++ b/tests/unit/test_reproduce_routing.py
@@ -151,6 +151,9 @@ def test_default_with_no_env_verifies_against_the_official_front(
     (line,) = _shim_lines(result)
     assert "verify_published_record.py" in line
     assert "--sku H100 --date 2026-08-24" in line
+    # The default is the raw-only full re-derivation; --receipts is the
+    # opt-out for the fast receipts-only recompute.
+    assert "--full" in line
     assert _shim_env(result) == "https://data.getcomputable.com"
 
 
@@ -192,6 +195,17 @@ def test_full_mode_routes_to_the_raw_only_public_derivation(shim, data_dir):
     (line,) = _shim_lines(result)
     assert "verify_published_record.py" in line
     assert "--sku H100 --date 2026-09-01 --full" in line
+    assert _shim_env(result) == "https://data.getcomputable.com"
+
+
+def test_receipts_flag_routes_to_the_receipts_only_verifier(shim, data_dir):
+    result = _run(shim, data_dir, "--receipts", "h100", "2026-09-01")
+
+    assert result.returncode == 0, result.stderr
+    (line,) = _shim_lines(result)
+    assert "verify_published_record.py" in line
+    assert "--sku H100 --date 2026-09-01" in line
+    assert "--full" not in line
     assert _shim_env(result) == "https://data.getcomputable.com"
 
 


### PR DESCRIPTION
## Summary
- add `./reproduce --full <sku> <date>` to derive attendance, liveness, weights, carried votes, IQM, and final values from verified public history
- port the attendance classifier onto `upstream_status`, carry basis, filter verdicts, timing, and observation flags
- refuse with typed errors when the observable history or required raw terms are insufficient
- accept the public series `window_basis_at` metadata used to anchor retained history

Published weights, liveness scores, attendance factors, no-price counters, and current carried vote outputs are never calculation inputs.

## Verification
- `ruff check` on changed Python files
- `bash -n reproduce`
- 91 affected unit tests passed
- live `./reproduce --full h100 2026-09-01`: 27 observations, 27 MATCH, 0 MISMATCH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getcomputable/codesmith/gpu-index/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790837704&installation_model_id=433894&pr_number=41&repository=getcomputable%2Fgpu-index&return_to=https%3A%2F%2Fgithub.com%2Fgetcomputable%2Fgpu-index%2Fpull%2F41&signature=ea4361f468f35ef80b82e51bca0870f0461c5da4ee575d3d4057ee21197eae3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->