### PR TITLE
feat: reproduce --collect checks the latest print's inputs against live provider prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ summary: 30 observation(s): 30 MATCH, 0 MISMATCH
 Run `./reproduce --receipts` for the receipts-only value check; `--producer`
 and `--lane` replay a local collection record rather than the published one.
 
+To compare the latest print with prices visible at its sources now, run
+`./reproduce --collect <h100|h200|b300|b200>`. It reports `SAME`, `MOVED`,
+`UNREACHABLE`, or `SKIPPED` for every receipt and summarizes the counts.
+`MOVED` means the provider price changed since capture, not that the published
+record disagrees; marketplace prices move often, so that result is expected.
+Only the latest print can be checked this way because past source inputs are not
+retroactively observable.
+
 ## What is here
 
 | Path | What it is |

--- a/reproduce
+++ b/reproduce
@@ -6,6 +6,7 @@
 #
 #   ./reproduce <h100|h200|b300|b200> <YYYY-MM-DD[THH]>
 #   ./reproduce --full <sku>          <YYYY-MM-DD[THH]>
+#   ./reproduce --collect <sku>
 #   ./reproduce --producer <sku>      <YYYY-MM-DD[THH]>
 #   ./reproduce --lane <panel_id>     <YYYY-MM-DD[THH]>
 #   ./reproduce --frozen <b300|b200>  <YYYY-MM-DD>
@@ -50,6 +51,7 @@ usage() {
   cat >&2 <<'EOF'
 usage: reproduce <h100|h200|b300|b200> <YYYY-MM-DD[THH]>
        reproduce --receipts <sku> <YYYY-MM-DD[THH]>
+       reproduce --collect <sku>
        reproduce --producer <sku> <YYYY-MM-DD[THH]>
        reproduce --lane <panel_id> <YYYY-MM-DD[THH]>
        reproduce --frozen <b300|b200> <YYYY-MM-DD>
@@ -66,6 +68,10 @@ usage: reproduce <h100|h200|b300|b200> <YYYY-MM-DD[THH]>
                     all-match, 1 mismatch/digest FAIL, 2 could not verify
   --receipts        the fast check: recompute each value from its own
                     published receipts only (no weight re-derivation)
+  --collect         collect current source prices for the latest print
+                    and compare them with its receipts. Past source
+                    inputs are not retroactively observable. A changed
+                    price is expected and is not a verification failure
   --producer        force the internal producer-record replay/verify
   --lane <panel_id> run any configured panel lane, e.g. h100_broad or
                     h200_broad (configured lanes that are not public SKUs)
@@ -82,14 +88,28 @@ PRODUCER=0
 # cannot-combine guard for the other modes on explicit flags only.
 FULL=1
 FULL_EXPLICIT=0
+COLLECT=0
 case "${1:-}" in
   --frozen) MODE=frozen; shift ;;
   --lane) MODE=lane; shift ;;
   --producer) PRODUCER=1; shift ;;
   --full) FULL=1; FULL_EXPLICIT=1; shift ;;
   --receipts) FULL=0; shift ;;
+  --collect) COLLECT=1; shift ;;
   -h|--help) usage ;;
 esac
+
+if [ "$COLLECT" -eq 1 ]; then
+  [ $# -eq 1 ] || usage
+  ARG=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  case "$ARG" in
+    h100|h200|b300|b200) ;;
+    *) echo "unknown sku '$1' (expected h100, h200, b300, or b200)" >&2; exit 2 ;;
+  esac
+  ROOT=$(cd "$(dirname "$0")" && pwd)
+  PY=${PYTHON:-python3}
+  exec "$PY" "$ROOT/scripts/collect_latest_receipts.py" --sku "$ARG"
+fi
 
 [ $# -eq 2 ] || usage
 ARG=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')

--- a/scripts/collect_latest_receipts.py
+++ b/scripts/collect_latest_receipts.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Computable
+"""Compare the latest public receipts with prices visible at their sources."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import math
+import sys
+from collections import Counter
+from contextlib import contextmanager
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Optional, Sequence
+
+_ROOT = Path(__file__).resolve().parent.parent
+for _path in (str(_ROOT / "src"), str(_ROOT)):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+import gpu_index.common.http as common_http  # noqa: E402
+from gpu_index.common.bucket import (  # noqa: E402
+    PUBLIC_BASE_URL_ENV,
+    BucketConfig,
+)
+from gpu_index.index.panel import (  # noqa: E402
+    compile_screens,
+    member_eligible_rows,
+    panel_calc_params,
+    resolve_member_print,
+)
+from gpu_index.index.panel_config import load_panel_config  # noqa: E402
+from gpu_index.observatory.catalog import load_sku_catalog  # noqa: E402
+from gpu_index.observatory.collect import collect_all  # noqa: E402
+from gpu_index.observatory.config import (  # noqa: E402
+    load_observatory_config,
+    resolve_catalog_path,
+    sources_by_id,
+)
+from gpu_index.observatory.snapshot import normalize_observation  # noqa: E402
+from gpu_index.observatory.sources import COLLECTORS  # noqa: E402
+from gpu_index.published.reader import PublishedRecordReader  # noqa: E402
+
+VERIFY_USER_AGENT = (
+    "CGI-Verify/1.0 (+https://github.com/getcomputable/gpu-index)"
+)
+DEFAULT_PUBLIC_BASE_URL = "https://data.getcomputable.com"
+PANEL_CONFIGS = {
+    "B200": _ROOT / "config" / "index_panel_b200.json",
+    "B300": _ROOT / "config" / "index_panel_b300.json",
+    "H100": _ROOT / "config" / "index_panel_h100_sxm.json",
+    "H200": _ROOT / "config" / "index_panel_h200_sxm.json",
+}
+PUBLIC_SKUS = tuple(sorted(PANEL_CONFIGS))
+
+SAME = "SAME"
+MOVED = "MOVED"
+UNREACHABLE = "UNREACHABLE"
+SKIPPED = "SKIPPED"
+
+SKIP_KEY_REQUIRED = "api-key-required"
+SKIP_RETRIEVAL_RESTRICTED = "retrieval-restricted"
+VALID_POLICY_SKIP_REASONS = frozenset(
+    {SKIP_KEY_REQUIRED, SKIP_RETRIEVAL_RESTRICTED}
+)
+
+# Add a source here only when its existing collector must not be invoked by
+# an anonymous user-run check. An unregistered source also fails closed before
+# any request because its receipt URL cannot be approved.
+SOURCE_SKIP_REASONS: Mapping[str, str] = {}
+
+
+class CollectionError(RuntimeError):
+    """The latest print could not be selected or compared safely."""
+
+
+def _one_line(value: Any, limit: int = 240) -> str:
+    text = " ".join(str(value).split())
+    return text if len(text) <= limit else text[: limit - 3] + "..."
+
+
+def _decimal(value: Any) -> Optional[Decimal]:
+    if isinstance(value, bool) or not isinstance(value, (int, float, Decimal)):
+        return None
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    return parsed if parsed.is_finite() and parsed > 0 else None
+
+
+def _price(value: Decimal) -> str:
+    return f"{value:.6f}"
+
+
+@dataclass(frozen=True)
+class SeatCheck:
+    sku: str
+    source_id: str
+    state: str
+    receipt_price: Optional[Decimal] = None
+    collected_price: Optional[Decimal] = None
+    reason: Optional[str] = None
+    detail: Optional[str] = None
+
+    def line(self) -> str:
+        parts = [self.sku, f"source={self.source_id}", self.state]
+        if self.receipt_price is not None:
+            parts.append(f"receipt={_price(self.receipt_price)}")
+        if self.collected_price is not None:
+            parts.append(f"collected={_price(self.collected_price)}")
+        if self.reason is not None:
+            parts.append(f"reason={self.reason}")
+        if self.detail:
+            parts.append(f"detail={self.detail!r}")
+        if self.state == MOVED:
+            parts.append("price changed since capture")
+        return " ".join(parts)
+
+
+@dataclass(frozen=True)
+class CollectionReport:
+    sku: str
+    observed_at: str
+    methodology_id: str
+    checks: tuple[SeatCheck, ...]
+
+    @property
+    def comparison_count(self) -> int:
+        return sum(check.state in (SAME, MOVED) for check in self.checks)
+
+    @property
+    def exit_code(self) -> int:
+        return 0 if self.comparison_count else 2
+
+    def lines(self) -> list[str]:
+        counts = Counter(check.state for check in self.checks)
+        return [
+            (
+                f"latest print: {self.sku} {self.observed_at} "
+                f"({self.methodology_id})"
+            ),
+            *(check.line() for check in self.checks),
+            (
+                f"summary: {len(self.checks)} seat(s): "
+                f"{counts[SAME]} SAME, {counts[MOVED]} MOVED, "
+                f"{counts[UNREACHABLE]} UNREACHABLE, "
+                f"{counts[SKIPPED]} SKIPPED"
+            ),
+        ]
+
+
+@contextmanager
+def _verifier_identity():
+    with common_http.user_agent_scope(VERIFY_USER_AGENT):
+        yield
+
+
+def _select_latest_observation(envelope: Optional[dict], sku: str) -> dict:
+    if envelope is None:
+        raise CollectionError("the public front has no latest.json")
+    data = envelope.get("data") or {}
+    versions = data.get("versions") or []
+    pointers = [entry for entry in versions if entry.get("sku") == sku]
+    if len(pointers) != 1:
+        raise CollectionError(
+            f"latest.json has {len(pointers)} current-version pointers for {sku}"
+        )
+    methodology = pointers[0].get("methodology_id")
+    matches = [
+        observation
+        for observation in (data.get("observations") or [])
+        if observation.get("sku") == sku
+        and observation.get("methodology_id") == methodology
+    ]
+    if len(matches) != 1:
+        raise CollectionError(
+            f"latest.json has {len(matches)} {sku} prints for current "
+            f"methodology {methodology!r}"
+        )
+    return matches[0]
+
+
+def _https_values(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        if value.startswith("https://"):
+            yield value
+    elif isinstance(value, Mapping):
+        for item in value.values():
+            yield from _https_values(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _https_values(item)
+
+
+def _declared_urls(
+    collector: Callable[..., Any], source_config: Mapping[str, Any]
+) -> frozenset[str]:
+    module = importlib.import_module(collector.__module__)
+    values: list[Any] = []
+    for name in ("URL", "URL_BASE", "URLS"):
+        if hasattr(module, name):
+            values.append(getattr(module, name))
+    values.append(source_config.get("options") or {})
+    return frozenset(url for value in values for url in _https_values(value))
+
+
+def _fx_records(receipt: Mapping[str, Any], observed_at: str) -> dict:
+    if receipt.get("currency") != "EUR":
+        return {}
+    rate = _decimal(receipt.get("fx_rate"))
+    if rate is None:
+        return {}
+    return {observed_at[:10]: {"rates": {"USD": float(rate)}}}
+
+
+def _resolve_collected_price(
+    *,
+    receipt: Mapping[str, Any],
+    result: Mapping[str, Any],
+    catalog: Mapping[str, Any],
+    params: Mapping[str, Any],
+    screens: Mapping[str, Any],
+    observed_at: str,
+) -> Optional[Decimal]:
+    source_id = str(receipt["source_id"])
+    member = screens["members"].get(source_id)
+    if member is None:
+        return None
+    entry = {
+        "source_id": source_id,
+        "status": "ok",
+        "observations": [
+            normalize_observation(row, catalog)
+            for row in (result.get("observations") or [])
+        ],
+        "book_stats": result.get("book_stats"),
+    }
+    rows = member_eligible_rows(
+        entry,
+        skus=member["skus"],
+        reject_patterns=screens["reject"],
+        require_patterns=member["require"],
+        eligible_tiers=params["eligible_tiers"],
+        extra_require=member["extra_require"],
+    )
+    chosen = resolve_member_print(
+        rows,
+        source_entry=entry,
+        statistic=member["statistic"],
+        statistic_params=params["statistic_params"],
+        obs_date=observed_at[:10],
+        fx_records=_fx_records(receipt, observed_at),
+        fx_max_staleness_days=params["fx_max_staleness_days"],
+    )
+    if not chosen or chosen.get("held_out") or chosen.get("fx_unavailable"):
+        return None
+    return _decimal(chosen.get("usd_per_gpu_hr"))
+
+
+def _skip(
+    sku: str,
+    source_id: str,
+    reason: str,
+    *,
+    receipt_price: Optional[Decimal] = None,
+) -> SeatCheck:
+    return SeatCheck(
+        sku=sku,
+        source_id=source_id,
+        state=SKIPPED,
+        receipt_price=receipt_price,
+        reason=reason,
+    )
+
+
+def _compare_observation(
+    observation: Mapping[str, Any],
+    *,
+    panel_config: Mapping[str, Any],
+    observatory_config: Mapping[str, Any],
+    catalog: Mapping[str, Any],
+    collectors: Mapping[str, Callable[..., dict]],
+    skip_reasons: Mapping[str, str],
+    approved_urls: Optional[Mapping[str, Sequence[str]]] = None,
+) -> CollectionReport:
+    sku = str(observation["sku"])
+    methodology = str(observation["methodology_id"])
+    if panel_config["calc"]["methodology_id"] != methodology:
+        raise CollectionError(
+            f"this checkout has {panel_config['calc']['methodology_id']!r} for "
+            f"{sku}, but the public front points to {methodology!r}; update the "
+            "checkout before collecting"
+        )
+    invalid_reasons = sorted(set(skip_reasons.values()) - VALID_POLICY_SKIP_REASONS)
+    if invalid_reasons:
+        raise CollectionError(f"unknown source skip reasons: {invalid_reasons}")
+
+    receipts = list(observation.get("receipts") or [])
+    source_configs = sources_by_id(dict(observatory_config))
+    checks: list[Optional[SeatCheck]] = [None] * len(receipts)
+    runnable: set[str] = set()
+
+    for index, receipt in enumerate(receipts):
+        source_id = str(receipt.get("source_id") or "unknown")
+        receipt_price = _decimal(receipt.get("price"))
+        if receipt_price is None:
+            checks[index] = _skip(sku, source_id, "receipt-price-unavailable")
+            continue
+        policy_reason = skip_reasons.get(source_id)
+        if policy_reason is not None:
+            checks[index] = _skip(
+                sku, source_id, policy_reason, receipt_price=receipt_price
+            )
+            continue
+        collector = collectors.get(source_id)
+        if collector is None:
+            checks[index] = _skip(
+                sku,
+                source_id,
+                "collector-unavailable",
+                receipt_price=receipt_price,
+            )
+            continue
+        source_config = source_configs.get(source_id)
+        if source_config is None:
+            checks[index] = _skip(
+                sku,
+                source_id,
+                "source-configuration-unavailable",
+                receipt_price=receipt_price,
+            )
+            continue
+        source_url = receipt.get("source_url")
+        declared = (
+            frozenset(approved_urls.get(source_id, ()))
+            if approved_urls is not None
+            else _declared_urls(collector, source_config)
+        )
+        if not isinstance(source_url, str) or source_url not in declared:
+            checks[index] = _skip(
+                sku,
+                source_id,
+                "receipt-source-url-not-approved",
+                receipt_price=receipt_price,
+            )
+            continue
+        runnable.add(source_id)
+
+    collected = (
+        collect_all(dict(observatory_config), collectors, only=runnable)
+        if runnable
+        else []
+    )
+    results = {
+        result["source_id"]: result
+        for result in collected
+    }
+    params = panel_calc_params(dict(panel_config))
+    screens = compile_screens(params)
+    observed_at = str(observation["observed_at"])
+
+    for index, receipt in enumerate(receipts):
+        if checks[index] is not None:
+            continue
+        source_id = str(receipt["source_id"])
+        receipt_price = _decimal(receipt.get("price"))
+        result = results.get(source_id)
+        if result is None:
+            checks[index] = SeatCheck(
+                sku,
+                source_id,
+                UNREACHABLE,
+                receipt_price=receipt_price,
+                reason="collector-result-missing",
+            )
+            continue
+        if result.get("status") != "ok":
+            checks[index] = SeatCheck(
+                sku,
+                source_id,
+                UNREACHABLE,
+                receipt_price=receipt_price,
+                reason=str(result.get("failure_kind") or "collector-error"),
+                detail=_one_line(result.get("error") or result.get("status")),
+            )
+            continue
+        if result.get("url") != receipt.get("source_url"):
+            checks[index] = SeatCheck(
+                sku,
+                source_id,
+                UNREACHABLE,
+                receipt_price=receipt_price,
+                reason="collector-source-url-mismatch",
+                detail=_one_line(result.get("url")),
+            )
+            continue
+        try:
+            collected_price = _resolve_collected_price(
+                receipt=receipt,
+                result=result,
+                catalog=catalog,
+                params=params,
+                screens=screens,
+                observed_at=observed_at,
+            )
+        except Exception as exc:  # one source failure must not hide other receipts
+            checks[index] = SeatCheck(
+                sku,
+                source_id,
+                UNREACHABLE,
+                receipt_price=receipt_price,
+                reason="resolution-error",
+                detail=_one_line(f"{type(exc).__name__}: {exc}"),
+            )
+            continue
+        if collected_price is None:
+            checks[index] = SeatCheck(
+                sku,
+                source_id,
+                UNREACHABLE,
+                receipt_price=receipt_price,
+                reason="no-current-price",
+            )
+            continue
+        state = SAME if collected_price == receipt_price else MOVED
+        checks[index] = SeatCheck(
+            sku,
+            source_id,
+            state,
+            receipt_price=receipt_price,
+            collected_price=collected_price,
+        )
+
+    if any(check is None for check in checks):
+        raise CollectionError("a receipt produced no report line")
+    return CollectionReport(
+        sku=sku,
+        observed_at=observed_at,
+        methodology_id=methodology,
+        checks=tuple(check for check in checks if check is not None),
+    )
+
+
+def collect_latest_receipts(
+    sku: str,
+    *,
+    reader_factory: Optional[Callable[[], Any]] = None,
+    panel_config: Optional[Mapping[str, Any]] = None,
+    observatory_config: Optional[Mapping[str, Any]] = None,
+    catalog: Optional[Mapping[str, Any]] = None,
+    collectors: Optional[Mapping[str, Callable[..., dict]]] = None,
+    skip_reasons: Optional[Mapping[str, str]] = None,
+    approved_urls: Optional[Mapping[str, Sequence[str]]] = None,
+) -> CollectionReport:
+    """Collect and compare every receipt in one SKU's current public print."""
+    normalized_sku = sku.upper()
+    if normalized_sku not in PUBLIC_SKUS:
+        raise CollectionError(
+            f"unknown sku {sku!r} (expected b200, b300, h100, or h200)"
+        )
+    loaded_panel = (
+        load_panel_config(PANEL_CONFIGS[normalized_sku])
+        if panel_config is None
+        else panel_config
+    )
+    loaded_observatory = (
+        load_observatory_config()
+        if observatory_config is None
+        else observatory_config
+    )
+    loaded_catalog = (
+        load_sku_catalog(resolve_catalog_path(dict(loaded_observatory)))
+        if catalog is None
+        else catalog
+    )
+    active_collectors = COLLECTORS if collectors is None else collectors
+    active_skips = SOURCE_SKIP_REASONS if skip_reasons is None else skip_reasons
+
+    with _verifier_identity():
+        if reader_factory is None:
+            config = BucketConfig.from_env(
+                {PUBLIC_BASE_URL_ENV: DEFAULT_PUBLIC_BASE_URL}
+            )
+            reader = PublishedRecordReader(config)
+        else:
+            reader = reader_factory()
+        latest = reader.read_latest()
+        observation = _select_latest_observation(latest, normalized_sku)
+        return _compare_observation(
+            observation,
+            panel_config=loaded_panel,
+            observatory_config=loaded_observatory,
+            catalog=loaded_catalog,
+            collectors=active_collectors,
+            skip_reasons=active_skips,
+            approved_urls=approved_urls,
+        )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="collect current source prices for the latest public print"
+    )
+    parser.add_argument("--sku", required=True, choices=[s.lower() for s in PUBLIC_SKUS])
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        report = collect_latest_receipts(args.sku)
+    except Exception as exc:
+        print(f"collect failed: {_one_line(f'{type(exc).__name__}: {exc}')}", file=sys.stderr)
+        return 2
+    for line in report.lines():
+        print(line)
+    return report.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gpu_index/common/bucket.py
+++ b/src/gpu_index/common/bucket.py
@@ -201,13 +201,13 @@ class PublicReadStore:
         from gpu_index.common.http import (
             DEFAULT_TIMEOUT,
             MAX_RESPONSE_BYTES,
-            UA,
+            current_user_agent,
         )
 
         self.base_url = base_url.rstrip("/")
         self.max_bytes = MAX_RESPONSE_BYTES if max_bytes is None else int(max_bytes)
         self._timeout = DEFAULT_TIMEOUT if timeout is None else float(timeout)
-        self._user_agent = UA
+        self._user_agent = current_user_agent()
         self._client = client  # injectable for tests (httpx mock transports)
 
     def _http(self):

--- a/src/gpu_index/common/http.py
+++ b/src/gpu_index/common/http.py
@@ -12,13 +12,15 @@ integrity is part of the contract:
 
 from __future__ import annotations
 
+import contextvars
 import re
 import ssl
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Optional
+from contextlib import contextmanager
+from typing import Iterator, Optional
 
 # One identity across every repository that collects for this index. The
 # +URL is getcomputable.com and NOT this repository: a repo URL stops
@@ -28,6 +30,26 @@ UA = (
     "CGI-Collector/1.0 (+https://getcomputable.com; "
     "team@getcomputable.com)"
 )
+_USER_AGENT_OVERRIDE: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "gpu_index_user_agent_override", default=None
+)
+
+
+def current_user_agent() -> str:
+    """Return the request identity installed for the current execution context."""
+    return _USER_AGENT_OVERRIDE.get() or UA
+
+
+@contextmanager
+def user_agent_scope(value: str) -> Iterator[None]:
+    """Temporarily identify requests from this execution context as ``value``."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("user agent must be a non-empty string")
+    token = _USER_AGENT_OVERRIDE.set(value)
+    try:
+        yield
+    finally:
+        _USER_AGENT_OVERRIDE.reset(token)
 
 DEFAULT_TIMEOUT = 30.0
 # urllib's timeout bounds each socket OPERATION (connect / one recv), not the
@@ -115,7 +137,7 @@ def fetch(
     req = urllib.request.Request(
         url,
         data=data,
-        headers={"User-Agent": UA, **(headers or {})},
+        headers={"User-Agent": current_user_agent(), **(headers or {})},
     )
     with _OPENER.open(req, timeout=timeout) as resp:
         return read_body_capped(resp, wall_clock_limit=wall_clock_limit).decode(

--- a/src/gpu_index/observatory/collect.py
+++ b/src/gpu_index/observatory/collect.py
@@ -13,6 +13,7 @@ errors — visible holes, never a silently shorter list.
 
 from __future__ import annotations
 
+import contextvars
 import threading
 import time
 from typing import Any, Callable, Dict, List, Mapping, Optional, Set
@@ -103,7 +104,8 @@ def call_with_deadline(
         except BaseException as exc:  # noqa: BLE001 — reported by the caller
             outcome["error"] = exc
 
-    worker = threading.Thread(target=_target, daemon=True)
+    context = contextvars.copy_context()
+    worker = threading.Thread(target=context.run, args=(_target,), daemon=True)
     worker.start()
     worker.join(deadline)
     if worker.is_alive():

--- a/tests/live/test_collect_latest_live.py
+++ b/tests/live/test_collect_latest_live.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Computable
+"""Live acceptance for current collection of the latest H100 receipts."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.live
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPRODUCE = REPO_ROOT / "reproduce"
+SUMMARY = re.compile(
+    r"^summary: (\d+) seat\(s\): (\d+) SAME, (\d+) MOVED, "
+    r"(\d+) UNREACHABLE, (\d+) SKIPPED$",
+    re.MULTILINE,
+)
+
+
+def test_current_h100_receipts_include_at_least_one_live_comparison():
+    env = dict(os.environ)
+    env["PYTHON"] = sys.executable
+    env.pop("GPU_INDEX_PUBLIC_BASE_URL", None)
+    result = subprocess.run(
+        [str(REPRODUCE), "--collect", "h100"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=1800,
+    )
+    report = (
+        f"./reproduce --collect h100 exited {result.returncode}\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    assert result.returncode == 0, report
+    summary = SUMMARY.search(result.stdout)
+    assert summary is not None, report
+    total, same, moved, unreachable, skipped = (
+        int(value) for value in summary.groups()
+    )
+    assert total > 0, report
+    assert same + moved > 0, report
+    assert same + moved + unreachable + skipped == total, report

--- a/tests/unit/test_collect_latest_receipts.py
+++ b/tests/unit/test_collect_latest_receipts.py
@@ -1,0 +1,614 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Computable
+"""Current receipt collection: state, policy, identity, and exit pins."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from threading import Event
+
+import pytest
+
+import gpu_index.common.http as common_http
+from gpu_index.index.panel import compile_screens, panel_calc_params
+from gpu_index.index.panel_config import load_panel_config
+from gpu_index.observatory.catalog import load_sku_catalog
+from gpu_index.observatory.collect import DeadlineExceeded, call_with_deadline
+from gpu_index.observatory.config import (
+    load_observatory_config,
+    resolve_catalog_path,
+)
+from gpu_index.observatory.observation import observation as raw_observation
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "collect_latest_receipts.py"
+
+
+@pytest.fixture(scope="module")
+def collect_module():
+    spec = importlib.util.spec_from_file_location(
+        "collect_latest_receipts_for_test", SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def configs():
+    observatory = load_observatory_config()
+    return (
+        load_panel_config(REPO_ROOT / "config" / "index_panel_h100_sxm.json"),
+        observatory,
+        load_sku_catalog(resolve_catalog_path(observatory)),
+    )
+
+
+def _receipt(source_id: str, source_url: str, price: float, label: str) -> dict:
+    return {
+        "source_id": source_id,
+        "source_url": source_url,
+        "price": price,
+        "currency": "USD",
+        "sku_identifier": label,
+        "status": "ok",
+    }
+
+
+def _latest(receipts: list[dict]) -> dict:
+    return {
+        "data": {
+            "versions": [
+                {
+                    "sku": "H100",
+                    "current_version": 2,
+                    "methodology_id": "h100_sxm_v1_calc_v8",
+                }
+            ],
+            "observations": [
+                {
+                    "sku": "H100",
+                    "methodology_id": "h100_sxm_v1_calc_v6",
+                    "observed_at": "2026-08-31T23:15:00.000Z",
+                    "receipts": [],
+                },
+                {
+                    "sku": "H100",
+                    "methodology_id": "h100_sxm_v1_calc_v8",
+                    "observed_at": "2026-09-01T08:45:00.000Z",
+                    "receipts": receipts,
+                },
+            ],
+        }
+    }
+
+
+class _Reader:
+    def __init__(self, latest: dict, expected_user_agent: str) -> None:
+        assert common_http.current_user_agent() == expected_user_agent
+        self.latest = latest
+
+    def read_latest(self) -> dict:
+        assert common_http.current_user_agent().startswith("CGI-Verify/1.0")
+        return self.latest
+
+
+def _collector(
+    *,
+    source_id: str,
+    source_url: str,
+    label: str,
+    price: float,
+    expected_user_agent: str,
+    calls: list[str],
+):
+    def collect(*, timeout, options=None):
+        del timeout, options
+        assert common_http.current_user_agent() == expected_user_agent
+        calls.append(source_id)
+        return {
+            "source_id": source_id,
+            "method": "fixture",
+            "url": source_url,
+            "observations": [
+                raw_observation(
+                    sku_identifier=label,
+                    price_per_gpu_hr=price,
+                    raw_value=str(price),
+                )
+            ],
+        }
+
+    return collect
+
+
+def test_fixture_emits_all_four_states_and_restores_identity(
+    collect_module, configs
+):
+    panel, observatory, catalog = configs
+    urls = {
+        "civo": "https://www.civo.com/pricing",
+        "coreweave": "https://www.coreweave.com/pricing",
+        "crusoe": "https://www.crusoe.ai/cloud/pricing",
+        "lambda": "https://lambda.ai/pricing",
+    }
+    labels = {
+        "civo": "NVIDIA H100 SXM",
+        "coreweave": "NVIDIA HGX H100",
+        "crusoe": "NVIDIA H100 80GB HGX",
+        "lambda": "NVIDIA H100 SXM",
+    }
+    receipts = [
+        _receipt("civo", urls["civo"], 2.99, labels["civo"]),
+        _receipt("coreweave", urls["coreweave"], 6.155, labels["coreweave"]),
+        _receipt("crusoe", urls["crusoe"], 3.9, labels["crusoe"]),
+        _receipt("lambda", urls["lambda"], 3.99, labels["lambda"]),
+    ]
+    calls: list[str] = []
+    verifier_ua = collect_module.VERIFY_USER_AGENT
+    collectors = {
+        "civo": _collector(
+            source_id="civo",
+            source_url=urls["civo"],
+            label=labels["civo"],
+            price=2.99,
+            expected_user_agent=verifier_ua,
+            calls=calls,
+        ),
+        "coreweave": _collector(
+            source_id="coreweave",
+            source_url=urls["coreweave"],
+            label=labels["coreweave"],
+            price=6.5,
+            expected_user_agent=verifier_ua,
+            calls=calls,
+        ),
+    }
+
+    def unreachable(*, timeout, options=None):
+        del timeout, options
+        assert common_http.current_user_agent() == verifier_ua
+        calls.append("crusoe")
+        raise OSError("fixture host did not answer")
+
+    collectors["crusoe"] = unreachable
+
+    def forbidden(*, timeout, options=None):  # pragma: no cover - must not run
+        del timeout, options
+        raise AssertionError("key-required source was fetched")
+
+    collectors["lambda"] = forbidden
+    original_ua = common_http.current_user_agent()
+
+    report = collect_module.collect_latest_receipts(
+        "h100",
+        reader_factory=lambda: _Reader(_latest(receipts), verifier_ua),
+        panel_config=panel,
+        observatory_config=observatory,
+        catalog=catalog,
+        collectors=collectors,
+        skip_reasons={"lambda": collect_module.SKIP_KEY_REQUIRED},
+        approved_urls={source_id: [url] for source_id, url in urls.items()},
+    )
+
+    assert common_http.current_user_agent() == original_ua
+    assert [check.state for check in report.checks] == [
+        collect_module.SAME,
+        collect_module.MOVED,
+        collect_module.UNREACHABLE,
+        collect_module.SKIPPED,
+    ]
+    assert sorted(calls) == ["civo", "coreweave", "crusoe"]
+    assert report.checks[2].reason == "fetch"
+    assert report.checks[3].reason == "api-key-required"
+    assert report.exit_code == 0
+
+    lines = report.lines()
+    assert len(lines) == len(receipts) + 2
+    assert "price changed since capture" in lines[2]
+    assert "discrep" not in lines[2].lower()
+    assert "mismatch" not in lines[2].lower()
+    assert lines[-1] == (
+        "summary: 4 seat(s): 1 SAME, 1 MOVED, "
+        "1 UNREACHABLE, 1 SKIPPED"
+    )
+
+
+def test_retrieval_restricted_source_is_not_called_and_exit_is_two(
+    collect_module, configs
+):
+    panel, observatory, catalog = configs
+    receipt = _receipt(
+        "lambda", "https://lambda.ai/pricing", 3.99, "NVIDIA H100 SXM"
+    )
+
+    calls = []
+
+    def forbidden(*, timeout, options=None):  # pragma: no cover - must not run
+        del timeout, options
+        calls.append("lambda")
+        raise AssertionError("retrieval-restricted source was fetched")
+
+    report = collect_module.collect_latest_receipts(
+        "H100",
+        reader_factory=lambda: _Reader(
+            _latest([receipt]), collect_module.VERIFY_USER_AGENT
+        ),
+        panel_config=panel,
+        observatory_config=observatory,
+        catalog=catalog,
+        collectors={"lambda": forbidden},
+        skip_reasons={
+            "lambda": collect_module.SKIP_RETRIEVAL_RESTRICTED
+        },
+        approved_urls={"lambda": ["https://lambda.ai/pricing"]},
+    )
+
+    assert report.checks[0].state == collect_module.SKIPPED
+    assert report.checks[0].reason == "retrieval-restricted"
+    assert calls == []
+    assert report.comparison_count == 0
+    assert report.exit_code == 2
+
+
+@pytest.mark.parametrize(
+    ("checks", "expected"),
+    [
+        (["SAME"], 0),
+        (["MOVED"], 0),
+        (["UNREACHABLE", "SKIPPED"], 2),
+        ([], 2),
+    ],
+)
+def test_exit_codes_are_checked_directly_without_a_pipeline(
+    collect_module, checks, expected
+):
+    report = collect_module.CollectionReport(
+        sku="H100",
+        observed_at="2026-09-01T08:45:00.000Z",
+        methodology_id="h100_sxm_v1_calc_v8",
+        checks=tuple(
+            collect_module.SeatCheck("H100", f"source-{i}", state)
+            for i, state in enumerate(checks)
+        ),
+    )
+
+    assert report.exit_code == expected
+
+
+def test_current_pointer_selects_the_latest_methodology(collect_module):
+    current = collect_module._select_latest_observation(  # noqa: SLF001
+        _latest([]), "H100"
+    )
+    assert current["methodology_id"] == "h100_sxm_v1_calc_v8"
+    assert current["observed_at"] == "2026-09-01T08:45:00.000Z"
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (lambda latest: latest["data"].update(versions=[]), "0 current-version"),
+        (
+            lambda latest: latest["data"]["versions"].append(
+                dict(latest["data"]["versions"][0])
+            ),
+            "2 current-version",
+        ),
+        (lambda latest: latest["data"].update(observations=[]), "0 H100 prints"),
+        (
+            lambda latest: latest["data"]["observations"].append(
+                dict(latest["data"]["observations"][-1])
+            ),
+            "2 H100 prints",
+        ),
+    ],
+)
+def test_current_pointer_rejects_missing_or_ambiguous_entries(
+    collect_module, mutator, message
+):
+    latest = _latest([])
+    mutator(latest)
+    with pytest.raises(collect_module.CollectionError, match=message):
+        collect_module._select_latest_observation(latest, "H100")  # noqa: SLF001
+
+
+def test_current_pointer_rejects_a_missing_public_document(collect_module):
+    with pytest.raises(collect_module.CollectionError, match="no latest.json"):
+        collect_module._select_latest_observation(None, "H100")  # noqa: SLF001
+
+
+def test_production_url_discovery_approves_only_declared_urls(
+    collect_module, configs
+):
+    panel, observatory, catalog = configs
+    source_url = "https://www.civo.com/pricing"
+    calls: list[str] = []
+    collector = _collector(
+        source_id="civo",
+        source_url=source_url,
+        label="NVIDIA H100 SXM",
+        price=2.99,
+        expected_user_agent=collect_module.VERIFY_USER_AGENT,
+        calls=calls,
+    )
+    module_name = "test_collect_latest_declared_urls"
+    collector.__module__ = module_name
+    source_module = types.ModuleType(module_name)
+    source_module.URL = source_url
+    source_module.URL_BASE = "https://api.example.test/v1"
+    source_module.URLS = ("https://cdn.example.test/prices",)
+    sys.modules[module_name] = source_module
+    try:
+        declared = collect_module._declared_urls(  # noqa: SLF001
+            collector,
+            {
+                "options": {
+                    "nested": ["https://options.example.test/prices", "ignored"]
+                }
+            },
+        )
+        assert declared == {
+            source_url,
+            "https://api.example.test/v1",
+            "https://cdn.example.test/prices",
+            "https://options.example.test/prices",
+        }
+        report = collect_module.collect_latest_receipts(
+            "h100",
+            reader_factory=lambda: _Reader(
+                _latest(
+                    [_receipt("civo", source_url, 2.99, "NVIDIA H100 SXM")]
+                ),
+                collect_module.VERIFY_USER_AGENT,
+            ),
+            panel_config=panel,
+            observatory_config=observatory,
+            catalog=catalog,
+            collectors={"civo": collector},
+        )
+    finally:
+        del sys.modules[module_name]
+
+    assert calls == ["civo"]
+    assert report.checks[0].state == collect_module.SAME
+
+
+def test_eur_receipt_uses_its_captured_fx_rate(collect_module):
+    panel = load_panel_config(REPO_ROOT / "config" / "index_panel_b300.json")
+    observatory = load_observatory_config()
+    catalog = load_sku_catalog(resolve_catalog_path(observatory))
+    params = panel_calc_params(panel)
+    screens = compile_screens(params)
+    result = {
+        "source_id": "scaleway",
+        "status": "ok",
+        "observations": [
+            raw_observation(
+                sku_identifier="B300-SXM",
+                price_per_gpu_hr=9.48,
+                currency="EUR",
+                raw_value="9.48",
+                raw_unit="eur_per_gpu_hr",
+            )
+        ],
+    }
+
+    price = collect_module._resolve_collected_price(  # noqa: SLF001
+        receipt={"source_id": "scaleway", "currency": "EUR", "fx_rate": 1.1},
+        result=result,
+        catalog=catalog,
+        params=params,
+        screens=screens,
+        observed_at="2026-09-01T08:45:00.000Z",
+    )
+    assert price == collect_module.Decimal("10.428")
+
+    unavailable = collect_module._resolve_collected_price(  # noqa: SLF001
+        receipt={"source_id": "scaleway", "currency": "EUR"},
+        result=result,
+        catalog=catalog,
+        params=params,
+        screens=screens,
+        observed_at="2026-09-01T08:45:00.000Z",
+    )
+    assert unavailable is None
+
+
+def test_verifier_identity_survives_an_abandoned_collector_thread(
+    collect_module,
+):
+    started = Event()
+    release = Event()
+    finished = Event()
+    seen: list[str] = []
+
+    def delayed(*, timeout, options=None):
+        del timeout, options
+        started.set()
+        release.wait(timeout=2)
+        seen.append(common_http.current_user_agent())
+        finished.set()
+
+    original = common_http.current_user_agent()
+    with collect_module._verifier_identity():  # noqa: SLF001
+        with pytest.raises(DeadlineExceeded):
+            call_with_deadline(delayed, timeout=1, deadline=0.01)
+        assert started.is_set()
+    assert common_http.current_user_agent() == original
+
+    release.set()
+    assert finished.wait(timeout=2)
+    assert seen == [collect_module.VERIFY_USER_AGENT]
+
+
+def test_unapproved_receipt_url_is_skipped_before_collection(
+    collect_module, configs
+):
+    panel, observatory, catalog = configs
+    receipt = _receipt(
+        "civo",
+        "https://unexpected.example/pricing",
+        2.99,
+        "NVIDIA H100 SXM",
+    )
+
+    def forbidden(*, timeout, options=None):  # pragma: no cover - must not run
+        del timeout, options
+        raise AssertionError("unapproved URL was fetched")
+
+    report = collect_module.collect_latest_receipts(
+        "h100",
+        reader_factory=lambda: _Reader(
+            _latest([receipt]), collect_module.VERIFY_USER_AGENT
+        ),
+        panel_config=panel,
+        observatory_config=observatory,
+        catalog=catalog,
+        collectors={"civo": forbidden},
+        approved_urls={"civo": ["https://www.civo.com/pricing"]},
+    )
+
+    assert report.checks[0].state == collect_module.SKIPPED
+    assert report.checks[0].reason == "receipt-source-url-not-approved"
+    assert report.exit_code == 2
+
+
+def test_preflight_failures_are_typed_without_running_collectors(
+    collect_module, configs
+):
+    panel, observatory, catalog = configs
+    base = _latest([])["data"]["observations"][-1]
+
+    cases = [
+        (
+            _receipt("civo", "https://www.civo.com/pricing", 0, "NVIDIA H100 SXM"),
+            {"civo": lambda **kwargs: kwargs},
+            "receipt-price-unavailable",
+        ),
+        (
+            _receipt(
+                "civo", "https://www.civo.com/pricing", 2.99, "NVIDIA H100 SXM"
+            ),
+            {},
+            "collector-unavailable",
+        ),
+        (
+            _receipt(
+                "not-configured",
+                "https://prices.example.test",
+                2.99,
+                "NVIDIA H100 SXM",
+            ),
+            {"not-configured": lambda **kwargs: kwargs},
+            "source-configuration-unavailable",
+        ),
+    ]
+    for receipt, collectors, expected_reason in cases:
+        report = collect_module._compare_observation(  # noqa: SLF001
+            {**base, "receipts": [receipt]},
+            panel_config=panel,
+            observatory_config=observatory,
+            catalog=catalog,
+            collectors=collectors,
+            skip_reasons={},
+            approved_urls={},
+        )
+        assert report.checks[0].state == collect_module.SKIPPED
+        assert report.checks[0].reason == expected_reason
+
+    with pytest.raises(collect_module.CollectionError, match="unknown source skip"):
+        collect_module._compare_observation(  # noqa: SLF001
+            base,
+            panel_config=panel,
+            observatory_config=observatory,
+            catalog=catalog,
+            collectors={},
+            skip_reasons={"civo": "silent"},
+        )
+
+
+def test_missing_and_mismatched_results_are_typed(
+    collect_module, configs, monkeypatch
+):
+    panel, observatory, catalog = configs
+    source_url = "https://www.civo.com/pricing"
+    observation = _latest(
+        [_receipt("civo", source_url, 2.99, "NVIDIA H100 SXM")]
+    )["data"]["observations"][-1]
+    collectors = {"civo": lambda **kwargs: kwargs}
+    options = {
+        "panel_config": panel,
+        "observatory_config": observatory,
+        "catalog": catalog,
+        "collectors": collectors,
+        "skip_reasons": {},
+        "approved_urls": {"civo": [source_url]},
+    }
+
+    monkeypatch.setattr(collect_module, "collect_all", lambda *args, **kwargs: [])
+    missing = collect_module._compare_observation(observation, **options)  # noqa: SLF001
+    assert missing.checks[0].reason == "collector-result-missing"
+
+    monkeypatch.setattr(
+        collect_module,
+        "collect_all",
+        lambda *args, **kwargs: [
+            {
+                "source_id": "civo",
+                "status": "ok",
+                "url": "https://other.example.test/pricing",
+                "observations": [],
+            }
+        ],
+    )
+    mismatched = collect_module._compare_observation(  # noqa: SLF001
+        observation, **options
+    )
+    assert mismatched.checks[0].reason == "collector-source-url-mismatch"
+
+
+def test_resolution_failures_are_typed_and_do_not_compare(
+    collect_module, configs, monkeypatch
+):
+    panel, observatory, catalog = configs
+    source_url = "https://www.civo.com/pricing"
+    observation = _latest(
+        [_receipt("civo", source_url, 2.99, "NVIDIA H100 SXM")]
+    )["data"]["observations"][-1]
+    result = {
+        "source_id": "civo",
+        "status": "ok",
+        "url": source_url,
+        "observations": [],
+    }
+    monkeypatch.setattr(
+        collect_module, "collect_all", lambda *args, **kwargs: [result]
+    )
+    options = {
+        "panel_config": panel,
+        "observatory_config": observatory,
+        "catalog": catalog,
+        "collectors": {"civo": lambda **kwargs: kwargs},
+        "skip_reasons": {},
+        "approved_urls": {"civo": [source_url]},
+    }
+
+    original = collect_module._resolve_collected_price  # noqa: SLF001
+
+    def fail_resolution(**kwargs):
+        del kwargs
+        raise ValueError("fixture resolution failed")
+
+    monkeypatch.setattr(collect_module, "_resolve_collected_price", fail_resolution)
+    failed = collect_module._compare_observation(observation, **options)  # noqa: SLF001
+    assert failed.checks[0].reason == "resolution-error"
+
+    monkeypatch.setattr(collect_module, "_resolve_collected_price", original)
+    empty = collect_module._compare_observation(observation, **options)  # noqa: SLF001
+    assert empty.checks[0].reason == "no-current-price"
+    assert empty.exit_code == 2

--- a/tests/unit/test_reproduce_routing.py
+++ b/tests/unit/test_reproduce_routing.py
@@ -209,6 +209,42 @@ def test_receipts_flag_routes_to_the_receipts_only_verifier(shim, data_dir):
     assert _shim_env(result) == "https://data.getcomputable.com"
 
 
+@pytest.mark.parametrize("sku", ["h100", "h200", "b300", "b200"])
+def test_collect_flag_routes_only_the_sku_to_current_collection(
+    shim, data_dir, sku
+):
+    result = _run(shim, data_dir, "--collect", sku)
+
+    assert result.returncode == 0, result.stderr
+    (line,) = _shim_lines(result)
+    assert f"collect_latest_receipts.py --sku {sku}" in line
+    assert "verify_published_record.py" not in line
+    assert _shim_env(result) == ""
+
+
+def test_collect_flag_refuses_dates_and_unknown_skus(shim, data_dir):
+    with_date = _run(
+        shim, data_dir, "--collect", "h100", "2026-09-01"
+    )
+    assert with_date.returncode == 2
+    assert "usage: reproduce" in with_date.stderr
+    assert not _shim_lines(with_date)
+
+    unknown = _run(shim, data_dir, "--collect", "h300")
+    assert unknown.returncode == 2
+    assert "unknown sku 'h300'" in unknown.stderr
+    assert not _shim_lines(unknown)
+
+
+def test_usage_says_historical_source_inputs_cannot_be_observed(
+    shim, data_dir
+):
+    result = _run(shim, data_dir, "--help")
+    assert result.returncode == 2
+    assert "Past source" in result.stderr
+    assert "not retroactively observable" in result.stderr
+
+
 def test_producer_flag_forces_the_internal_replay(shim, data_dir):
     # Even with a published day file present, --producer keeps the
     # previous producer-record semantics verbatim.


### PR DESCRIPTION
Adds `./reproduce --collect <sku>`: fetch the latest print's receipts and run this repository's own collectors live against each receipt's source URL, one line per seat: SAME, MOVED (the price changed since capture), UNREACHABLE (typed reason), or SKIPPED (typed policy reason). Exit 0 when at least one seat compared; exit 2 when nothing could be compared. Latest print only: past source inputs are not retroactively observable, and the usage text says so.

Verifier runs identify with their own User-Agent (`CGI-Verify/1.0`), distinct from the pipeline collector, and only receipt-declared source URLs are fetched. Existing modes are routed additively (zero removed lines in `reproduce`).

Evidence: full suite 1595 passed, ruff clean; live `--collect h100` 13 SAME / 3 UNREACHABLE (typed) and `--collect b200` 8 SAME, both exit 0; error paths produce typed one-liners, never stack traces.

Known cosmetic follow-ups, deliberately not blocking: collector progress lines print to stdout ahead of the report, and a reachable source with no current comparable price reads UNREACHABLE (reason `no-current-price`) rather than a dedicated word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getcomputable/codesmith/gpu-index/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790892425&installation_model_id=433894&pr_number=42&repository=getcomputable%2Fgpu-index&return_to=https%3A%2F%2Fgithub.com%2Fgetcomputable%2Fgpu-index%2Fpull%2F42&signature=4f1243327a83b8e559e500347e573f9a62976f2cd4ecff2268fec6a5669777c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->