### PR TITLE
Seat Hyperbolic on the H100-SXM and H200-SXM panels under book_median (calc_v10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ that produced it; any parameter change touching a published day mints a
 new methodology_id, and prior versions stay frozen and readable under
 their own keyspaces. Newest first.
 
+## 2026-09-03
+
+- **Hyperbolic seated on the H100-SXM and H200-SXM panels.** New lane
+  mints `h100_sxm_v1_calc_v10` (17 seats, was 16) and `h200_sxm_v1_calc_v10`
+  (14 seats, was 13), each adding `hyperbolic` as a label-screened SXM seat
+  (`require_tokens: ["SXM"]`; Hyperbolic's own `gpuFormFactor` labels the
+  rows). The seat prices under a new panel statistic, `book_median`: the
+  plain median of its screened SXM book, weight 1 per row, no population
+  floor, no volume weighting. The population is every row the seat's
+  screens admit, including options Hyperbolic lists as disabled or without
+  availability; one row prints as itself and two print as their midpoint
+  (a two-row book at 3.99 and 4.92 prints 4.455). The statistic is named
+  in the SKU document each lane runs from; the published `calc_params` do
+  not list per-seat statistics. No other member, screen, or threshold
+  changed. Measured on the seat alone over the recorded 15-minute slots
+  from 2026-08-29 to 2026-09-03, the median print moves on 9% (H100) and
+  13% (H200) of slot transitions with mean moves of 1.6% and 1.4%, against
+  4% of transitions with mean moves of 0.7% and 0.6% under the
+  lowest-eligible rule, with the same largest single move (52% H100, 23%
+  H200).
+- Hyperbolic is classed `marketplace` in the observatory config, with
+  `first_party: true`, the same disclosure Vast.ai and Lium carry: its
+  terms describe a marketplace over third-party suppliers. The class is a
+  disclosure field; nothing in the calculation branches on it.
+- Fallback member weights on these two lanes are now derived (uniform 1/n)
+  rather than authored. The fallback vector prices the panel only until it
+  latches to dynamic weighting, which both lanes did on 2026-08-28, so the
+  new series differs from the old one over 2026-08-23 to 2026-08-27 and
+  agrees with it from 2026-08-28 until Hyperbolic's first collection on
+  2026-08-29. Measured stamp by stamp against the previous
+  methodology: H100-SXM differs by 1.0% to 1.6% on average per day in that
+  window, at most 3.07% (2026-08-27 12:00Z, 3.493 versus 3.386); H200-SXM
+  by at most 1.23%. From 2026-08-28 onward, before Hyperbolic collected,
+  the two series agree to 0.02%. The prior series stays published under its
+  own keyspace.
+- Effective from the production promotion timestamp recorded in each
+  panel's `versions.succession` (`effective_from`) in `latest.json`.
+  Prior prints under earlier methodology ids remain published, unchanged,
+  under their own keyspaces. A consumer plotting across the boundary will
+  see more frequent intra-day movement from the new seat. Measured on the
+  published composite over every 15-minute stamp from 2026-08-29 to
+  2026-09-03 against the previous methodology: the level moves by −0.22%
+  (H100-SXM) and +0.25% (H200-SXM) on average, +0.34% and +0.91% over the
+  last 24 hours of that window; the standard deviation of stamp-to-stamp
+  changes rises from 0.21% to 0.45% (H100) and from 0.20% to 0.36% (H200);
+  stamps moving more than 1% rise from 9 to 44 (H100) and from 3 to 17
+  (H200), of which 34 and 13 coincide with a change in Hyperbolic's own
+  print, whose book median steps between 3.19, 4.02 and 4.85 as options
+  come and go; the largest single stamp-to-stamp move rises from 1.94% to
+  3.29% (H100). No stamp went dark that was priced before. This is a
+  property of the new methodology, not a correction to the old one.
+- Hyperbolic's receipt field `provider_class` publishes as null until the
+  publisher is rebuilt with the seat's disclosure table. Its `gpu_variant`
+  and `vram_gb` publish as null for the same reason Vast.ai's and Lium's
+  do: a statistic over several rows has no single row to project them
+  from. Its price and weight are complete.
+
 ## 2026-09-01
 
 - Change log restarted at the public launch of this repository. Earlier

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -99,9 +99,9 @@ This is the general methodology, chip-generic: panel membership, per-SKU paramet
 
 What CGI delivers: one reference price for GPU compute that no single provider can materially move, that both sides of a trade can settle against, and that anyone can recompute from the public record. Each claim below is checkable against that record. Using any Index Value to settle or construct a financial product requires a separate written license (LICENSE-DATA.md Section 2).
 
-- Prices are collected every 15 minutes from 28 providers, unfiltered.
+- Prices are collected every 15 minutes from 29 providers through 31 collector sources, unfiltered.
 - An index value, a stability band, and a liveness weight vector publish for every observation, every 15 minutes. There is no designated fixing time.
-- Each panel provider contributes one number per observation: its lowest eligible on-demand listing, except order books, which contribute a volume-weighted median.
+- Each panel provider contributes one number per observation: its lowest eligible on-demand listing, except order books, which contribute a median of their asks: volume-weighted where the venue discloses volume, plain where it does not.
 - The index is an interquantile mean over votes, not a weighted average: the weighted mean of the central third of the vote mass. Each provider votes at its price and its price plus and minus its own standard deviation.
 - Liveness weights are computed from measured behavior: whether a provider's recent moves anticipated the rest of the panel. No weight requires a per-provider human decision.
 - The index history is a pure function of the published record plus published parameters. Published observations are never revised.
@@ -153,7 +153,7 @@ Symbols: `p_i` is provider i's observed price, `sd_i` its standard deviation ove
 
 ### 3.1 Coverage
 
-Every 15 minutes, 28 providers, every chip model they price (NVIDIA, AMD, Intel; datacenter and consumer parts). Collection is not filtered to current panels, chips, or eligible tiers. A page listing eleven chips across four tiers is recorded in full.
+Every 15 minutes, 29 providers through 31 collector sources (Compute Pulse and Sesterce are each read on two surfaces), every chip model they price (NVIDIA, AMD, Intel; datacenter and consumer parts). Collection is not filtered to current panels, chips, or eligible tiers. A page listing eleven chips across four tiers is recorded in full.
 
 Every panel is a selection over this record, not a separate collection effort.
 
@@ -165,7 +165,7 @@ Each provider carries two disclosure fields: `source_type` and `first_party`.
 | --- | --- | --- |
 | `direct_principal` | Owns or operates the hardware | Verda, Nebius, CoreWeave, Lambda |
 | `direct_partnered` | Sells capacity under direct arrangement | RunPod (Secure), Latitude.sh |
-| `marketplace` | Third-party hosts; price includes host spread | Vast.ai, Lium |
+| `marketplace` | Third-party hosts; price includes host spread | Vast.ai, Lium, Hyperbolic |
 | `reseller` | Republishes another cloud's capacity | Shadeform |
 | `aggregator` | Publishes its observation of others' prices | Compute Pulse |
 | `hyperscaler` | Separate pricing regime | Oracle |
@@ -207,7 +207,7 @@ Aggregators and resellers are collected but never panel-eligible (section 4.1).
 | Visible holes | Every configured provider appears in every snapshot: success, error, or unimplemented. Never a silently shorter list. |
 | Transport | HTTPS-only including on redirect (a redirect to HTTP raises). Response bodies size-capped, with a wall-clock read limit bounding a slow-drip response a network timeout cannot see. Certificate verification never weakened. |
 | Extraction contract | Record the published figure alongside the normalization; state currency explicitly; fail loudly on reading nothing. A page that silently changed shape must error, not present as a healthy provider with no prices. No recipe aggregates across providers. |
-| Thin-observation gate | Fewer than 8 of the 28 collected providers read successfully: the observation is discarded and the interval left unclaimed so the next run retries. The gate counts collected providers, not panel members; panel sufficiency is the calculation's minimum-panel rule (section 7.5). Recording a thin snapshot would both stop retries and become the reading the calculation uses. |
+| Thin-observation gate | Fewer than 8 of the 31 collector sources read successfully: the observation is discarded and the interval left unclaimed so the next run retries. The gate counts collector sources, not panel members; panel sufficiency is the calculation's minimum-panel rule (section 7.5). Recording a thin snapshot would both stop retries and become the reading the calculation uses. |
 | Alarms | A missing previous day, or a previous day missing intervals, is reported on every run until resolved. |
 
 The provider roster: section 11. Per-provider extraction recipes live in the open source collector.
@@ -226,7 +226,7 @@ Excluded: aggregators, which publish no price of their own, and resellers, whose
 
 Exclusion is by panel construction, not by filter. The panel is an explicit enumerated list in the SKU document; nothing in the calculation branches on `source_type` or `first_party`, which are disclosure fields.
 
-> **Why marketplaces are in.** Vast.ai and Lium are the only venues on any live panel where the published price is a live transactable ask rather than a posted list rate, which makes them each panel's only direct read on clearing prices. Two disclosures follow: their prices embed a host and platform spread, and they are the only members where manipulation would be transactional rather than reputational, hence the specific prohibition in section 10 (Independence).
+> **Why marketplaces are in.** Vast.ai, Lium, and Hyperbolic are the only venues on any live panel where the published price comes from third-party asks rather than a posted list rate: Vast.ai and Lium publish live order books, and Hyperbolic lists its suppliers' rental options, including ones it marks disabled or without stated availability. That makes them each panel's only direct read on what hosts are asking. Two disclosures follow: their prices embed a host and platform spread, and they are the only members where manipulation would be transactional rather than reputational, hence the specific prohibition in section 10 (Independence).
 
 ### 4.2 Double counting
 
@@ -285,9 +285,11 @@ A provider publishing an order book needs a different statistic. The distinction
 | One list price | Lowest eligible | The minimum selects among that provider's own tiers and configurations |
 | A book of third-party asks | Median over the eligible host population | The lowest ask is one host's offer, frequently unverified, sometimes a single machine. It is not representative of the venue |
 
-Two order books are seated across the live panels: Vast.ai and Lium. Which statistic each seat uses is per-SKU configuration (SKU documents). Where the order-book statistic applies, it prices as the volume-weighted median of rentable on-demand per-GPU asks, weighted by each offer's GPU count, under two population conditions the SKU document binds. Population accounting: the stored book must prove the full eligible population was recorded, else the seat is held out rather than pricing a truncated, one-sided-low book; fail closed, deterministic on replay. Population floors, on the H-series panels: a book below the minimum distinct machines, hosts, or sellers holds the seat out with the counts recorded.
+Three order books are seated across the live panels: Vast.ai, Lium, and Hyperbolic. Which statistic each seat uses is per-SKU configuration (SKU documents). Four book statistics exist in the registry, three of which are volume-weighted (two Vast.ai variants and one Lium variant); the Vast.ai and Lium seats use them: they price as the volume-weighted median of rentable on-demand per-GPU asks, weighted by each offer's GPU count, under two population conditions the SKU document binds. Population accounting: the stored book must prove the full eligible population was recorded, else the seat is held out rather than pricing a truncated, one-sided-low book; fail closed, deterministic on replay. Population floors, on the H-series panels: a book below the minimum distinct machines, hosts, or sellers holds the seat out with the counts recorded. The third statistic, `book_median`, is the plain median of every screened USD ask with weight 1 per row: no volume weighting, because the venue discloses no usable volume, and no population floor or accounting gate, so the seat prints on every observation where its screened book is non-empty and the print passes the panel's jump screen (section 7). One ask prints as itself and two print as their midpoint. The population is every row the seat's screens admit, including options the venue lists as disabled or without availability. The Hyperbolic seats on the H100-SXM and H200-SXM panels use it.
 
 > **Why not the lowest ask?** On one real observation the lowest-price rule would have returned an unverified host 29% below the median.
+
+> **Why no floor on the plain median?** A floored median would have held the Hyperbolic seat out of 30% to 60% of the observations measured, and a seat that prints that rarely loses attendance (section 8.6) until it is excluded. Measured over the recorded observations from 2026-08-29 to 2026-09-03, the plain median moved on 9% (H100) and 13% (H200) of transitions with mean moves of 1.6% and 1.4%, against 4% of transitions with mean moves of 0.7% and 0.6% for the lowest ask, and the same largest moves. It follows the venue's typical ask rather than its single cheapest option.
 
 Every other panel member, including those classed `marketplace`, publishes a price list, so the lowest-eligible rule applies to them unchanged.
 
@@ -637,6 +639,7 @@ The roster is what the methodology needs from the code: who is collected, its so
 | GMI Cloud | see published records | none | active |
 | GPU.ai | see published records | none | active |
 | Hot Aisle | direct_principal | none | active |
+| Hyperbolic | marketplace | H100-SXM, H200-SXM | active |
 | Hyperstack | see published records | B300, B200, H100-SXM, H200-SXM | active |
 | Lambda | direct_principal | B200, H100-SXM | active |
 | Latitude.sh | direct_partnered | B300 | active |
@@ -661,6 +664,8 @@ Panel eligibility is by source class (section 4.1); membership is enumerated per
 
 **Lium** is the second seated order book: a Bittensor-subnet marketplace publishing its entire machine book in one response. It publishes no host-verification field, so no verification screen exists there and none is applied (geography likewise); both are recorded open decisions, and its full extraction record is being documented.
 
+**Hyperbolic** is the third seated order book: a marketplace whose public rental-options API answers without an account and lists every on-demand option currently offered. Each option carries a whole-option hourly total in cents and the GPU count it requires; the per-GPU price is that total divided by the required count, and an option without an integer count of at least one is refused rather than recorded as if it were a single GPU. Hyperbolic labels each option with its own GPU type and form factor, so SXM5 options self-label and the H100-SXM and H200-SXM seats admit them on that label alone, with the same screen excluding the PCIe options. Availability is recorded when published, may be missing, and never gates a price. The API also exposes Hyperbolic's supplier cost for each option; that field is never republished.
+
 ---
 
 ## 12. Parameters
@@ -675,8 +680,8 @@ Every value publishes inside each record. Changes require a new version. Paramet
 | --- | --- |
 | Collection interval | every 15 minutes |
 | Index / weight recomputation | every observation |
-| Providers collected | 28 |
-| Minimum providers to record an observation | 8 of 28 collected (panel-agnostic; section 3.5) |
+| Providers collected | 29 (31 collector sources) |
+| Minimum sources to record an observation | 8 of 31 collector sources (panel-agnostic; section 3.5) |
 | Retention | life of trade + 2 years |
 | Jump threshold | 25% |
 | Corroboration threshold | 10% |

--- a/config/index_panel_h100_sxm.json
+++ b/config/index_panel_h100_sxm.json
@@ -71,8 +71,8 @@
     "GH200"
   ],
   "calc": {
-    "methodology_id": "h100_sxm_v1_calc_v8",
-    "description": "calc_v8 attendance-weighted quarter-hour panel mint (h100_sxm_v1_calc_v8); METHODOLOGY.md is the binding methodology document",
+    "methodology_id": "h100_sxm_v1_calc_v10",
+    "description": "calc_v10 attendance-weighted quarter-hour panel mint (h100_sxm_v1_calc_v10); METHODOLOGY.md is the binding methodology document",
     "availability_verified_sources": ["lium", "vast"],
     "min_sources_to_claim": 5,
     "eligible_tiers": [
@@ -141,7 +141,6 @@
     {
       "source_id": "verda",
       "display_name": "Verda (formerly DataCrunch)",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -156,7 +155,6 @@
     {
       "source_id": "nebius",
       "display_name": "Nebius",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -171,7 +169,6 @@
     {
       "source_id": "coreweave",
       "display_name": "CoreWeave",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -186,7 +183,6 @@
     {
       "source_id": "lambda",
       "display_name": "Lambda",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -201,7 +197,6 @@
     {
       "source_id": "together",
       "display_name": "Together AI",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -216,7 +211,6 @@
     {
       "source_id": "hyperstack",
       "display_name": "Hyperstack (NexGen Cloud)",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -231,7 +225,6 @@
     {
       "source_id": "crusoe",
       "display_name": "Crusoe",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -246,7 +239,6 @@
     {
       "source_id": "tensorpool",
       "display_name": "TensorPool",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -261,7 +253,6 @@
     {
       "source_id": "scaleway",
       "display_name": "Scaleway",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -276,7 +267,6 @@
     {
       "source_id": "civo",
       "display_name": "Civo",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -291,7 +281,6 @@
     {
       "source_id": "voltagepark",
       "display_name": "Voltage Park",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -306,7 +295,6 @@
     {
       "source_id": "digitalocean",
       "display_name": "DigitalOcean",
-      "weight": 0.07,
       "skus": [
         "H100"
       ],
@@ -319,7 +307,6 @@
     {
       "source_id": "runpod",
       "display_name": "RunPod",
-      "weight": 0.05,
       "skus": [
         "H100"
       ],
@@ -337,7 +324,6 @@
     {
       "source_id": "massedcompute",
       "display_name": "Massed Compute",
-      "weight": 0.05,
       "skus": [
         "H100"
       ],
@@ -352,7 +338,6 @@
     {
       "source_id": "vast",
       "display_name": "Vast.ai",
-      "weight": 0.03,
       "skus": [
         "H100"
       ],
@@ -368,7 +353,6 @@
     {
       "source_id": "lium",
       "display_name": "Lium",
-      "weight": 0.03,
       "skus": [
         "H100"
       ],
@@ -380,6 +364,21 @@
         ]
       },
       "notes": "live probe 2026-08-23: machine_name 'NVIDIA H100 80GB HBM3' (the SXM device string; the PCIe part self-labels 'NVIDIA H100 PCIe' in the same book). Statistic seat with book floors; probe found 2 machines (both RU, one operator), so the seat prints nothing until the book deepens. NO verified field exists on lium and no geo screen is applied -- recorded open methodology calls"
+    },
+    {
+      "source_id": "hyperbolic",
+      "display_name": "Hyperbolic",
+      "skus": [
+        "H100"
+      ],
+      "statistic": "book_median",
+      "variant": {
+        "mode": "label",
+        "require_tokens": [
+          "SXM"
+        ]
+      },
+      "notes": "Hyperbolic builds sku_identifier from its own gpuType + gpuFormFactor, so the SXM5 rows self-label ('H100 SXM5') and the PCIe rows say PCIE. A label-mode screen admits the SXM module and excludes PCIe without a declaration."
     }
   ]
 }

--- a/config/index_panel_h200_sxm.json
+++ b/config/index_panel_h200_sxm.json
@@ -68,8 +68,8 @@
     "H20"
   ],
   "calc": {
-    "methodology_id": "h200_sxm_v1_calc_v8",
-    "description": "calc_v8 attendance-weighted quarter-hour panel mint (h200_sxm_v1_calc_v8); METHODOLOGY.md is the binding methodology document",
+    "methodology_id": "h200_sxm_v1_calc_v10",
+    "description": "calc_v10 attendance-weighted quarter-hour panel mint (h200_sxm_v1_calc_v10); METHODOLOGY.md is the binding methodology document",
     "availability_verified_sources": [
       "lium",
       "vast"
@@ -141,7 +141,6 @@
     {
       "source_id": "verda",
       "display_name": "Verda (formerly DataCrunch)",
-      "weight": 0.082,
       "skus": [
         "H200"
       ],
@@ -156,7 +155,6 @@
     {
       "source_id": "nebius",
       "display_name": "Nebius",
-      "weight": 0.082,
       "skus": [
         "H200"
       ],
@@ -171,7 +169,6 @@
     {
       "source_id": "coreweave",
       "display_name": "CoreWeave",
-      "weight": 0.082,
       "skus": [
         "H200"
       ],
@@ -186,7 +183,6 @@
     {
       "source_id": "together",
       "display_name": "Together AI",
-      "weight": 0.082,
       "skus": [
         "H200"
       ],
@@ -201,7 +197,6 @@
     {
       "source_id": "hyperstack",
       "display_name": "Hyperstack (NexGen Cloud)",
-      "weight": 0.082,
       "skus": [
         "H200"
       ],
@@ -216,7 +211,6 @@
     {
       "source_id": "crusoe",
       "display_name": "Crusoe",
-      "weight": 0.082,
       "skus": [
         "H200"
       ],
@@ -231,7 +225,6 @@
     {
       "source_id": "tensorpool",
       "display_name": "TensorPool",
-      "weight": 0.082,
       "skus": [
         "H200"
       ],
@@ -246,7 +239,6 @@
     {
       "source_id": "civo",
       "display_name": "Civo",
-      "weight": 0.082,
       "skus": [
         "H200"
       ],
@@ -261,7 +253,6 @@
     {
       "source_id": "sesterce",
       "display_name": "Sesterce",
-      "weight": 0.082,
       "skus": [
         "H200"
       ],
@@ -274,7 +265,6 @@
     {
       "source_id": "runpod",
       "display_name": "RunPod",
-      "weight": 0.082,
       "skus": [
         "H200"
       ],
@@ -290,7 +280,6 @@
     {
       "source_id": "digitalocean",
       "display_name": "DigitalOcean",
-      "weight": 0.082,
       "skus": [
         "H200"
       ],
@@ -303,7 +292,6 @@
     {
       "source_id": "vast",
       "display_name": "Vast.ai",
-      "weight": 0.049,
       "skus": [
         "H200"
       ],
@@ -317,7 +305,6 @@
     {
       "source_id": "lium",
       "display_name": "Lium",
-      "weight": 0.049,
       "skus": [
         "H200"
       ],
@@ -327,6 +314,21 @@
         "evidence": "Lium's machine_name is a GPU device-string passthrough and the live book carries 'NVIDIA H200' (FI) and 'NVIDIA H200 NVL' (PT) as distinct labels (probe 2026-08-23); the H200 product line has exactly two forms and the NVL form self-labels, so the bare device string is the SXM module. The seat-evidence rule grants this seat 'declared' explicitly; caveat recorded: this is device-string disambiguation, not an explicit provider SXM utterance -- under a stricter provider-utterance bar, downgrade to label-gated."
       },
       "notes": "statistic seat with book floors (probe: 1 machine, so the seat prints nothing until the book deepens). NO verified field exists on lium and no geo screen is applied -- recorded open methodology calls"
+    },
+    {
+      "source_id": "hyperbolic",
+      "display_name": "Hyperbolic",
+      "skus": [
+        "H200"
+      ],
+      "statistic": "book_median",
+      "variant": {
+        "mode": "label",
+        "require_tokens": [
+          "SXM"
+        ]
+      },
+      "notes": "Hyperbolic builds sku_identifier from its own gpuType + gpuFormFactor, so the SXM5 rows self-label ('H200 SXM5'). A label-mode screen admits the SXM module without a declaration."
     }
   ]
 }

--- a/config/raw_observatory.json
+++ b/config/raw_observatory.json
@@ -285,7 +285,7 @@
     {
       "source_id": "hyperbolic",
       "display_name": "Hyperbolic",
-      "source_type": "direct_partnered",
+      "source_type": "marketplace",
       "first_party": true,
       "notes": "Public no-auth /v2/alpha/on-demand/rental-options JSON — every on-demand option; costPerHourCents is the whole-option total, divided by required gpuCount (never defaulted) for per-GPU USD; missing totalAvailable stays unknown and availability never gates price; providerCostPerHourCents is deliberately never republished; unknown *PerHourCents keys fail closed."
     }

--- a/src/gpu_index/index/panel.py
+++ b/src/gpu_index/index/panel.py
@@ -40,11 +40,11 @@ What is panel-NEW, each a design-doc rule:
     held out of this observation (status ``uncorroborated_jump``) and its
     print enters neither the filter window nor the weight series (capture
     parity: a flagged row never became a print);
-  - three panel-scoped STATISTICS (section 4) with population-accounting
-    gates and thin-book floors, dispatched over the member's PRE-SCREENED
-    rows -- a deliberately different signature from the daily registry, so
-    the registry contract of the frozen ``vast_vwm_verified_us_ca`` id is
-    untouched (see PANEL_STATISTIC_FNS);
+  - four panel-scoped STATISTICS (section 4), including population-accounting
+    gates, thin-book floors, and the unfloored book median, dispatched over
+    the member's PRE-SCREENED rows -- a deliberately different signature from
+    the daily registry, so the registry contract of the frozen
+    ``vast_vwm_verified_us_ca`` id is untouched (see PANEL_STATISTIC_FNS);
   - weights come from the stage-2 OBSERVATION-mode engine
     (gpu_index.index.weights.compute_panel_weights: per-observation R-cutoff on the
     era grid, A2 attendance floor, hour-stamped vectors), advanced with
@@ -248,14 +248,16 @@ def _finite_number(value: Any) -> bool:
 # which is the NO-statistic default).
 #
 # Return contract: a print dict ({usd_per_gpu_hr, statistic, currency,
-# n_eligible_prints, gpu_volume, ...}), a hold-out dict ({"held_out":
-# {"reason": ..., counts...}}), or None (no book at all -- the member
-# simply has no print, same as the daily statistics' None).
+# n_eligible_prints, ...}; gpu_volume is present only for volume-weighted
+# statistics), a hold-out dict ({"held_out": {"reason": ..., counts...}}),
+# or None (no book at all -- the member simply has no print, same as the
+# daily statistics' None).
 
 # Chosen priors (METHODOLOGY.md section 6.2); config
 # calc.statistic_params overrides per statistic, and the RESOLVED values
 # ride calc_params so every artifact pins the floors it was priced under.
 PANEL_STATISTIC_PARAM_DEFAULTS: Dict[str, Dict[str, int]] = {
+    "book_median": {},
     "vast_vwm_verified_us_ca_v2": {},
     "vast_vwm_verified_us_ca_floor": {
         "min_population_machines": 5,
@@ -515,7 +517,59 @@ def lium_vwm_book_floor(
     }
 
 
+def book_median(
+    rows: Sequence[Dict[str, Any]],
+    *,
+    source_entry: Optional[Dict[str, Any]],
+    statistic: str,
+    params: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Plain median of every pre-screened USD row, weight 1 per row.
+
+    This id permanently has no population floor, no accounting gate, and no
+    volume weighting. The population includes every row passed by
+    ``member_eligible_rows``, including rows whose availability is zero or
+    unknown and rows whose ``extra.enabled`` is false; this statistic does no
+    additional screening. ``source_entry`` and ``params`` are accepted only
+    for the panel-registry call signature and do not affect the computation.
+
+    Small books deliberately print: N=1 is the one ask and N=2 is the midpoint
+    of the two asks. The ruling follows 421 Hyperbolic slots measured
+    2026-08-29..09-03: the minimum moved on 4% of transitions with mean moves
+    of 0.7% (H100) and 0.6% (H200), while the median moved on 9% / 1.6%
+    (H100) and 13% / 1.4% (H200); both had the same maximum moves, 52% / 23%.
+    A future floored or volume-weighted rule must use a new statistic id rather
+    than changing ``book_median``.
+    """
+    if not rows:
+        return None
+    prices: List[float] = []
+    rows_skipped_non_usd = 0
+    for row in rows:
+        usd = row.get("price_usd_gpu_hr")
+        if usd is None:
+            rows_skipped_non_usd += 1
+            continue
+        prices.append(float(usd))
+    if not prices:
+        return None
+    book = [(usd, 1) for usd in prices]
+    skip_counts = (
+        {"rows_skipped_non_usd": rows_skipped_non_usd}
+        if rows_skipped_non_usd
+        else {}
+    )
+    return {
+        "usd_per_gpu_hr": round(_weighted_median(book), 6),
+        "statistic": statistic,
+        "currency": "USD",
+        "n_eligible_prints": len(book),
+        **skip_counts,
+    }
+
+
 PANEL_STATISTIC_FNS = {
+    "book_median": book_median,
     "vast_vwm_verified_us_ca_v2": vast_vwm_verified_us_ca_v2,
     "vast_vwm_verified_us_ca_floor": vast_vwm_verified_us_ca_floor,
     "lium_vwm_book_floor": lium_vwm_book_floor,

--- a/src/gpu_index/index/panel_config.py
+++ b/src/gpu_index/index/panel_config.py
@@ -729,6 +729,32 @@ def _validate_members(members: Any) -> List[str]:
     # registry (the SOURCE_STATISTIC_FNS rule).
     from gpu_index.index.panel import PANEL_STATISTIC_FNS
 
+    # Derived-uniform fallback vector (mirrors the upstream collector's loader).
+    # `weight` is the FALLBACK vector only: consumed in fallback mode, and
+    # the fallback -> dynamic latch is permanent for the series, so after
+    # the switch these numbers set nobody's published weight (before it,
+    # they price the panel, and a replay from genesis re-prices that
+    # window with whatever vector the config carries). Hand-
+    # authoring the vector forces a judgement that no longer expresses
+    # anything, and for many panel sizes it is not even expressible: 1/17
+    # has no 6dp-exact representation summing to 1.0. Omitting `weight` on
+    # EVERY member derives uniform 1/n in full float precision instead.
+    # All-or-nothing: a partly authored vector blends an explicit judgement
+    # with a derived one with no non-arbitrary rule for the omitted seats.
+    entries = [m for m in members if isinstance(m, dict)]
+    authored = [m for m in entries if "weight" in m]
+    uniform: Optional[float] = None
+    if entries and not authored:
+        uniform = 1.0 / len(entries)
+    elif authored and len(authored) != len(entries):
+        missing = sorted(
+            str(m.get("source_id")) for m in entries if "weight" not in m
+        )
+        raise PanelConfigError(
+            f"member weights must be authored for every seat or omitted "
+            f"for every seat; {missing} omit weight while others set it"
+        )
+
     seen: set = set()
     weights: List[float] = []
     for member in members:
@@ -741,16 +767,24 @@ def _validate_members(members: Any) -> List[str]:
         if sid in seen:
             raise PanelConfigError(f"duplicate member source_id {sid!r}")
         seen.add(sid)
-        weight = member.get("weight")
-        _require_number(weight, f"member {sid!r} weight", lo=0)
-        if round(float(weight), 6) != float(weight):
-            # The pinned-vector precision (gpu_index.index.config's dynamic_weights
-            # rule): a >6dp weight forks the fallback vector at rounding.
-            raise PanelConfigError(
-                f"member {sid!r} weight must be exact at 6 decimal places, "
-                f"got {weight!r}"
-            )
-        weights.append(float(weight))
+        if uniform is None:
+            weight = member.get("weight")
+            _require_number(weight, f"member {sid!r} weight", lo=0)
+            if round(float(weight), 6) != float(weight):
+                # The pinned-vector precision (gpu_index.index.config's
+                # dynamic_weights rule): a >6dp weight forks the fallback
+                # vector at rounding. Only an AUTHORED weight can fork it.
+                raise PanelConfigError(
+                    f"member {sid!r} weight must be exact at 6 decimal "
+                    f"places, got {weight!r}"
+                )
+            weights.append(float(weight))
+        else:
+            # Derived, not authored: exempt from the 6dp pin (a value that
+            # alone defines the vector cannot fork it). Written back so
+            # every downstream consumer still reads a full vector.
+            member["weight"] = uniform
+            weights.append(uniform)
         skus = member.get("skus")
         if (
             not isinstance(skus, list)

--- a/tests/unit/test_collect_latest_receipts.py
+++ b/tests/unit/test_collect_latest_receipts.py
@@ -67,7 +67,7 @@ def _latest(receipts: list[dict]) -> dict:
                 {
                     "sku": "H100",
                     "current_version": 2,
-                    "methodology_id": "h100_sxm_v1_calc_v8",
+                    "methodology_id": "h100_sxm_v1_calc_v10",
                 }
             ],
             "observations": [
@@ -79,7 +79,7 @@ def _latest(receipts: list[dict]) -> dict:
                 },
                 {
                     "sku": "H100",
-                    "methodology_id": "h100_sxm_v1_calc_v8",
+                    "methodology_id": "h100_sxm_v1_calc_v10",
                     "observed_at": "2026-09-01T08:45:00.000Z",
                     "receipts": receipts,
                 },
@@ -271,7 +271,7 @@ def test_exit_codes_are_checked_directly_without_a_pipeline(
     report = collect_module.CollectionReport(
         sku="H100",
         observed_at="2026-09-01T08:45:00.000Z",
-        methodology_id="h100_sxm_v1_calc_v8",
+        methodology_id="h100_sxm_v1_calc_v10",
         checks=tuple(
             collect_module.SeatCheck("H100", f"source-{i}", state)
             for i, state in enumerate(checks)
@@ -285,7 +285,7 @@ def test_current_pointer_selects_the_latest_methodology(collect_module):
     current = collect_module._select_latest_observation(  # noqa: SLF001
         _latest([]), "H100"
     )
-    assert current["methodology_id"] == "h100_sxm_v1_calc_v8"
+    assert current["methodology_id"] == "h100_sxm_v1_calc_v10"
     assert current["observed_at"] == "2026-09-01T08:45:00.000Z"
 
 

--- a/tests/unit/test_observatory_source_hyperbolic.py
+++ b/tests/unit/test_observatory_source_hyperbolic.py
@@ -58,7 +58,7 @@ def test_source_id_matches_module():
     assert SOURCE_ID == "hyperbolic"
 
 
-def test_config_classifies_hyperbolic_as_first_party_partnered_source():
+def test_config_classifies_hyperbolic_as_first_party_marketplace_source():
     config = json.loads(
         (REPO_ROOT / "config" / "raw_observatory.json").read_text()
     )
@@ -66,7 +66,7 @@ def test_config_classifies_hyperbolic_as_first_party_partnered_source():
         row for row in config["sources"] if row["source_id"] == SOURCE_ID
     )
     assert source["display_name"] == "Hyperbolic"
-    assert source["source_type"] == "direct_partnered"
+    assert source["source_type"] == "marketplace"
     assert source["first_party"] is True
 
 

--- a/tests/unit/test_panel_configs.py
+++ b/tests/unit/test_panel_configs.py
@@ -75,25 +75,25 @@ LANES = {
     },
     "config/index_panel_h100_sxm.json": {
         "panel_id": "h100_sxm",
-        "methodology_id": "h100_sxm_v1_calc_v8",
+        "methodology_id": "h100_sxm_v1_calc_v10",
         "prefix": "index/h100_sxm",
         "genesis": "2026-08-23",
         "claim_floor": 5,
         "w_min": 0.025,
         "fx_lane": "ecb",  # scaleway bills EUR
-        "members": 16,
+        "members": 17,
         "stitched": False,
         "quarter_hour": True,
     },
     "config/index_panel_h200_sxm.json": {
         "panel_id": "h200_sxm",
-        "methodology_id": "h200_sxm_v1_calc_v8",
+        "methodology_id": "h200_sxm_v1_calc_v10",
         "prefix": "index/h200_sxm",
         "genesis": "2026-08-23",
         "claim_floor": 5,
         "w_min": 0.025,
         "fx_lane": "none",  # no EUR member seated
-        "members": 13,
+        "members": 14,
         "stitched": False,
         "quarter_hour": True,
     },
@@ -150,7 +150,9 @@ def test_all_six_load_and_match_the_lane_table(configs):
         assert calc["fx_lane"] == expected["fx_lane"], rel
         assert len(cfg["members"]) == expected["members"], rel
         # The loader enforced the 6dp-exact sum-to-1.0 rule; re-assert the
-        # arithmetic here so the invariant reads in THIS file too.
+        # arithmetic here so the invariant reads in THIS file too. A config
+        # that omits every weight has the uniform 1/n vector DERIVED by the
+        # loader (the upstream rule), which sums to 1.0 in float by construction.
         assert (
             abs(sum(m["weight"] for m in cfg["members"]) - 1.0) <= 1e-9
         ), rel
@@ -314,7 +316,7 @@ def test_sxm_panels_fail_closed_variant_posture(configs):
     """Design section 8: EVERY seat on a form-factor panel carries a
     variant rule (require_tokens or declared-with-evidence) -- a seat
     without one would print unscreened generic rows. Statistic seats are
-    exactly the two marketplaces."""
+    exactly the three marketplaces."""
     for rel in (
         "config/index_panel_h100_sxm.json",
         "config/index_panel_h200_sxm.json",
@@ -332,6 +334,7 @@ def test_sxm_panels_fail_closed_variant_posture(configs):
         assert stats == {
             "vast": "vast_vwm_verified_us_ca_floor",
             "lium": "lium_vwm_book_floor",
+            "hyperbolic": "book_median",
         }, rel
 
 

--- a/tests/unit/test_panel_engine.py
+++ b/tests/unit/test_panel_engine.py
@@ -10,10 +10,11 @@ thresholds, the tier ALLOW-LIST eligible_tiers with the retired
 interruptible_tiers key refused, and the member extra_require screen);
 the identity/variant screens' boundary-token behavior over
 stored sku_identifier (pre-catalog-change history, SXM5/alpha-digit
-splits, NVL-vs-NVLink boundaries); the three panel statistics (the
-population-accounting gate, both thin-book floors, hand-computed
-volume-weighted medians incl. the straddle-average rule and lium's
-extra.gpu_count volume); the calc-lane jump screen (quarantine,
+splits, NVL-vs-NVLink boundaries); the four panel statistics (the
+population-accounting gate, both thin-book floors, the unfloored plain
+book median, hand-computed volume-weighted medians incl. the
+straddle-average rule, and lium's extra.gpu_count volume); the
+calc-lane jump screen (quarantine,
 corroborated pass, starvation stand-down, missing-reference report-only,
 same-machine delta) and its artifact-only verdict reach (no window entry,
 no weight-series print, out of the eligible set); FX rules (EUR converts,
@@ -40,8 +41,10 @@ from gpu_index.index.composite import (
     _interquantile_mean,
 )
 from gpu_index.index.panel import (
+    PANEL_STATISTIC_PARAM_DEFAULTS,
     PANEL_STATISTIC_FNS,
     apply_panel_jump_screen,
+    book_median,
     compile_screens,
     compute_observation,
     jump_reference_prints,
@@ -50,6 +53,7 @@ from gpu_index.index.panel import (
     member_eligible_rows,
     panel_calc_params,
     record_source_for,
+    resolve_member_print,
     vast_vwm_verified_us_ca_floor,
     vast_vwm_verified_us_ca_v2,
     _token_patterns,
@@ -410,6 +414,56 @@ def test_config_record_sources_rejections():
     cfg = _config()
     _two_eras(cfg, "2026-08-26")
     validate_panel_config(cfg)
+
+
+def test_omitting_every_member_weight_derives_a_uniform_fallback_vector():
+    """The fallback vector may be derived rather than authored.
+
+    `weight` is the FALLBACK vector only; the fallback -> dynamic latch is
+    permanent, so on a switched panel these numbers set nobody's published
+    weight. Omitting them on every seat derives uniform 1/n.
+    """
+    cfg = _config()
+    n = len(cfg["members"])
+    for member in cfg["members"]:
+        member.pop("weight")
+    validate_panel_config(cfg)
+    derived = [m["weight"] for m in cfg["members"]]
+    assert derived == [1.0 / n] * n
+    assert abs(sum(derived) - 1.0) <= 1e-9
+
+
+def test_derived_uniform_weights_work_where_an_authored_vector_cannot():
+    """17 seats: 1/17 has no 6dp-exact representation summing to 1.0, so
+    an authored vector cannot express it without an arbitrary residue
+    seat. Derived weights sidestep it -- this is the h100_sxm calc_v10 case."""
+    cfg = _config()
+    for index in range(17 - len(cfg["members"])):
+        cfg["members"].append(_member(f"extra{index}", 0.0))
+    for member in cfg["members"]:
+        member.pop("weight")
+    assert len(cfg["members"]) == 17
+    validate_panel_config(cfg)
+    assert abs(sum(m["weight"] for m in cfg["members"]) - 1.0) <= 1e-9
+    assert round(cfg["members"][0]["weight"], 6) != cfg["members"][0]["weight"]
+
+
+def test_partly_authored_member_weights_are_refused():
+    """All-or-nothing: a mixed vector blends an explicit judgement with a
+    derived one, with no non-arbitrary rule for the omitted seats."""
+    cfg = _config()
+    cfg["members"][0].pop("weight")
+    with pytest.raises(PanelConfigError, match="every seat or omitted"):
+        validate_panel_config(cfg)
+
+
+def test_authored_member_weights_are_unchanged_by_the_derived_path():
+    """Regression: every other live panel authors its weights, and
+    fallback-mode index math must stay byte-identical for them."""
+    cfg = _config()
+    authored = [m["weight"] for m in cfg["members"]]
+    validate_panel_config(cfg)
+    assert [m["weight"] for m in cfg["members"]] == authored
 
 
 def test_config_member_rejections():
@@ -1720,10 +1774,12 @@ def test_config_manual_exclusion_rejections():
 
 def test_panel_registry_is_disjoint_from_the_daily_registry():
     assert set(PANEL_STATISTIC_FNS) == {
+        "book_median",
         "vast_vwm_verified_us_ca_v2",
         "vast_vwm_verified_us_ca_floor",
         "lium_vwm_book_floor",
     }
+    assert PANEL_STATISTIC_PARAM_DEFAULTS["book_median"] == {}
     assert not set(PANEL_STATISTIC_FNS) & set(SOURCE_STATISTIC_FNS)
 
 
@@ -1925,6 +1981,98 @@ def test_record_quarantined_observation_artifact_and_guard():
 
 
 # --------------------------------------------------------------- statistics
+
+
+@pytest.mark.parametrize(
+    ("prices", "expected"),
+    [
+        pytest.param([1.0, 9.0, 3.0], 3.0, id="odd"),
+        pytest.param([1.0, 9.0, 3.0, 5.0], 4.0, id="even"),
+        pytest.param([3.99, 4.92], 4.455, id="two-row-midpoint"),
+        pytest.param([7.25], 7.25, id="single"),
+    ],
+)
+def test_book_median_hand_computed_small_books(prices, expected):
+    rows = [_obs("H100", "H100 SXM", price) for price in prices]
+    assert book_median(
+        rows,
+        source_entry=None,
+        statistic="book_median",
+        params={},
+    ) == {
+        "usd_per_gpu_hr": expected,
+        "statistic": "book_median",
+        "currency": "USD",
+        "n_eligible_prints": len(prices),
+    }
+
+
+def test_book_median_skips_non_usd_and_keeps_disabled_rows():
+    rows = [
+        _obs("H100", "H100 SXM", 1.0, extra={"enabled": False}),
+        _obs("H100", "H100 SXM", 5.0, extra={"enabled": True}),
+        _obs("H100", "H100 SXM", None, native=4.0, currency="EUR"),
+    ]
+    assert book_median(
+        rows,
+        source_entry={"this": "is intentionally unused"},
+        statistic="book_median",
+        params={},
+    ) == {
+        "usd_per_gpu_hr": 3.0,
+        "statistic": "book_median",
+        "currency": "USD",
+        "n_eligible_prints": 2,
+        "rows_skipped_non_usd": 1,
+    }
+
+
+def test_book_median_returns_none_without_a_usd_book():
+    assert book_median(
+        [], source_entry=None, statistic="book_median", params={}
+    ) is None
+    assert book_median(
+        [_obs("H100", "H100 SXM", None, native=4.0, currency="EUR")],
+        source_entry=None,
+        statistic="book_median",
+        params={},
+    ) is None
+
+
+def test_book_median_registry_dispatch():
+    assert resolve_member_print(
+        [
+            _obs("H200", "H200 SXM5", 3.99, basis=8),
+            _obs("H200", "H200 SXM5", 4.92, basis=1),
+        ],
+        source_entry=None,
+        statistic="book_median",
+        statistic_params={"book_median": {}},
+        obs_date=GENESIS,
+        fx_records={},
+    ) == {
+        "usd_per_gpu_hr": 4.455,
+        "statistic": "book_median",
+        "currency": "USD",
+        "n_eligible_prints": 2,
+    }
+
+
+def test_book_median_member_and_empty_params_validate():
+    cfg = _config()
+    cfg["members"][0] = _member(
+        "hyperbolic",
+        0.3,
+        statistic="book_median",
+        variant={"mode": "label", "require_tokens": ["SXM"]},
+    )
+    validate_panel_config(cfg)
+    cfg["calc"]["statistic_params"] = {"book_median": {}}
+    validate_panel_config(cfg)
+    assert panel_calc_params(cfg)["statistic_params"]["book_median"] == {}
+    cfg["calc"]["statistic_params"] = {"book_median": {"anything": 1}}
+    with pytest.raises(PanelConfigError, match="unknown param 'anything'"):
+        validate_panel_config(cfg)
 
 
 def _vast_rows():

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -138,8 +138,8 @@ PUBLIC_NAMES = {
     },
     "gpu_index.index.panel": {
         "FxUnavailableError", "advance_panel_weight_state",
-        "advance_window", "apply_panel_jump_screen", "boundary_pattern",
-        "compile_screens",
+        "advance_window", "apply_panel_jump_screen", "book_median",
+        "boundary_pattern", "compile_screens",
         "compute_observation", "compute_panel_weights",
         "embedded_calc_params", "eur_to_usd", "evaluate_filter",
         "exclusion_applies", "filter_observation",


### PR DESCRIPTION
## Summary

The H100-SXM and H200-SXM lanes now run `h100_sxm_v1_calc_v10` / `h200_sxm_v1_calc_v10`, which seat Hyperbolic as a label-screened SXM member priced by a new panel statistic, `book_median`: the plain median of the seat's screened USD asks, weight 1 per row, no population floor, no volume weighting. Hyperbolic is classed `marketplace`. Fallback member weights on both lanes are derived (uniform 1/n) rather than authored.

This mirrors the upstream engine and moves the checkout to the methodology the public front serves since 2026-09-03 18:59Z, so `./reproduce --collect` works again.

`METHODOLOGY.md` gains the Hyperbolic roster row and extraction paragraph and describes `book_median` as the third book statistic beside the two volume-weighted ones.

## Verification

- `pytest`: 1607 passed, 22 deselected (live).
- `ruff check src tests`: clean.
- `./reproduce --collect h100` and `h200` against the live front: exit 0; Hyperbolic reads SAME (receipt 3.58 / 3.99 equals live collection).
- `./reproduce h100 2026-09-02T12` (stored hour, previous methodology): 4/4 MATCH.
- Every commit carries a DCO sign-off.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getcomputable/codesmith/gpu-index/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791060412&installation_model_id=433894&pr_number=44&repository=getcomputable%2Fgpu-index&return_to=https%3A%2F%2Fgithub.com%2Fgetcomputable%2Fgpu-index%2Fpull%2F44&signature=4fe204efe0f2460071b7fa810e9ba1d1836d493eacc1ed62d64fbdfcb31cc7c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
