### PR TITLE
fix(composite): a zero-weight seat is not a fault, drop it from the ballot

### DIFF
--- a/src/gpu_index/index/composite.py
+++ b/src/gpu_index/index/composite.py
@@ -924,9 +924,21 @@ def _weighted_quantile(
     must never touch its bytes."""
     if not 0 < q < 1:
         raise ValueError(f"quantile q must be in (0, 1), got {q}")
-    if any(w <= 0 for _, w in pairs):
-        raise ValueError("weighted quantile requires positive weights")
-    ordered = sorted(pairs)
+    # A zero-weight vote is SEATED BUT NOT CONTRIBUTING, which is a real
+    # state, not a fault: ballot weight is allocation x attendance, and a
+    # seat with no history has attendance 0. Weight_min floors the
+    # ALLOCATION, before attendance, so it never floors what arrives here
+    # (live 2026-09-02: vast and lium allocate at weight_max 0.30000 and
+    # reach the ballot at ~0.0058). Refusing zero therefore killed the
+    # lane on the first observation after any new seat was added.
+    #
+    # Dropped rather than admitted, because the tie branch below returns
+    # the mean of the boundary vote and its NEIGHBOUR: a zero-weight vote
+    # sitting at i+1 would move a published price it has no weight in.
+    # Negative weights still fail closed -- those are a real fault.
+    if any(w < 0 for _, w in pairs):
+        raise ValueError("weighted quantile requires non-negative weights")
+    ordered = sorted((value, w) for value, w in pairs if w > 0)
     target = q * sum(
         (Fraction(str(w)) for _, w in ordered), start=Fraction(0)
     )
@@ -962,9 +974,13 @@ def _interquantile_mean(
     last digit. Returns the exact Fraction; the caller quantizes once."""
     if not 0 < alpha <= Fraction(1, 2):
         raise ValueError(f"iqm alpha must be in (0, 1/2], got {alpha}")
-    if any(w <= 0 for _, w in pairs):
-        raise ValueError("interquantile mean requires positive weights")
-    ordered = sorted(pairs)
+    # Same seated-but-not-contributing case as _weighted_quantile above.
+    # A zero-weight vote already contributes nothing here (its overlap
+    # span is empty), so dropping it changes no arithmetic; it is dropped
+    # for one rule across both statistics rather than two.
+    if any(w < 0 for _, w in pairs):
+        raise ValueError("interquantile mean requires non-negative weights")
+    ordered = sorted((value, w) for value, w in pairs if w > 0)
     total = sum(
         (Fraction(str(w)) for _, w in ordered), start=Fraction(0)
     )

--- a/tests/unit/test_index_composite.py
+++ b/tests/unit/test_index_composite.py
@@ -1449,13 +1449,66 @@ def test_median_ci_composite_rejects_non_finite_votes():
         )
 
 
-def test_weighted_quantile_rejects_non_positive_weights():
+def test_weighted_quantile_rejects_negative_and_priceless_books():
     """The docstring promises a clean error, never an IndexError or a
-    silent average over a zero-weight book."""
-    with pytest.raises(ValueError, match="positive weights"):
+    silent average over a zero-weight book.
+
+    A NEGATIVE weight is a fault and still fails closed, while a
+    zero-weight vote is a seated-but-not-contributing member and is
+    dropped. A book of nothing but zeros therefore still refuses -- it has
+    no priceable vote left."""
+    with pytest.raises(ValueError, match="empty/zero-weight"):
         _weighted_quantile([(5.0, 0.0)], Fraction(1, 2))
-    with pytest.raises(ValueError, match="positive weights"):
+    with pytest.raises(ValueError, match="non-negative weights"):
         _weighted_quantile([(5.0, 1.0), (9.0, -0.1)], Fraction(1, 2))
+
+
+def test_zero_weight_votes_are_ignored_by_both_statistics():
+    """A seat with attendance 0 reaches the ballot at weight 0.
+
+    Ballot weight is allocation x attendance and weight_min floors the
+    ALLOCATION, before attendance -- so a brand-new seat arrives here at
+    exactly 0.0. That is seated-but-not-contributing, a real state, and
+    it must not change the number a panel prints.
+    """
+    live = [(10.0, 0.25), (11.0, 0.25), (12.0, 0.25), (13.0, 0.25)]
+    seated = live + [(999.0, 0.0)]
+    assert _weighted_quantile(seated, Fraction(1, 2)) == _weighted_quantile(
+        live, Fraction(1, 2)
+    )
+    assert _interquantile_mean(seated, Fraction(1, 6)) == _interquantile_mean(
+        live, Fraction(1, 6)
+    )
+
+
+def test_a_zero_weight_vote_cannot_move_a_boundary_tie():
+    """Why zero-weight votes are DROPPED rather than admitted.
+
+    The tie branch returns the mean of the boundary vote and its
+    neighbour. Admitting a zero-weight vote would let it sort into that
+    neighbour slot and move a published price it holds no weight in.
+    """
+    tie = [(10.0, 0.5), (20.0, 0.5)]
+    assert _weighted_quantile(tie, Fraction(1, 2)) == 15.0
+    wedged = [(10.0, 0.5), (11.0, 0.0), (20.0, 0.5)]
+    assert _weighted_quantile(wedged, Fraction(1, 2)) == 15.0
+
+
+def test_negative_weights_still_fail_closed():
+    """Zero is a state; negative is a fault, and stays refused."""
+    bad = [(10.0, 0.5), (11.0, -0.1)]
+    with pytest.raises(ValueError, match="non-negative"):
+        _weighted_quantile(bad, Fraction(1, 2))
+    with pytest.raises(ValueError, match="non-negative"):
+        _interquantile_mean(bad, Fraction(1, 6))
+
+
+def test_an_all_zero_ballot_still_refuses():
+    """Dropping zeros must not turn an empty book into a silent answer."""
+    with pytest.raises(ValueError):
+        _weighted_quantile([(10.0, 0.0), (11.0, 0.0)], Fraction(1, 2))
+    with pytest.raises(ValueError, match="empty/zero-weight"):
+        _interquantile_mean([(10.0, 0.0), (11.0, 0.0)], Fraction(1, 6))
 
 
 def test_config_rejects_median_votes_without_a_positive_floor(tmp_path):
@@ -1538,7 +1591,7 @@ def test_interquantile_mean_matches_its_integral_definition():
     for bad in (Fraction(0), Fraction(-1, 10), Fraction(51, 100)):
         with pytest.raises(ValueError, match="alpha"):
             _interquantile_mean(votes, bad)
-    with pytest.raises(ValueError, match="positive weights"):
+    with pytest.raises(ValueError, match="non-negative weights"):
         _interquantile_mean([(5.0, 1.0), (9.0, -0.1)], Fraction(1, 4))
     with pytest.raises(ValueError, match="empty"):
         _interquantile_mean([], Fraction(1, 4))


### PR DESCRIPTION
## Summary

Mirrors the producer's fix that landed before the calc_v10 mints: a vote with weight exactly 0 (a seat with no history yet, attendance 0) is dropped from the ballot instead of raising. Negative weights still fail closed; an all-zero ballot still refuses; `_weighted_median` is untouched, so the frozen B200 statistic keeps its bytes. No computed value changes for any existing stamp, because no vote could previously carry weight 0.

Without this, `./reproduce h100 2026-09-02` and `./reproduce h200 2026-09-02` fail with `weighted quantile requires positive weights` on the calc_v10 record, which contains Hyperbolic's zero-weight first stamps. The scheduled live-record job on `main` fails for that reason since the calc_v10 flip.

## Verification

- `pytest`: full suite green (1611 passed, 22 deselected live); the two old error-message contracts updated, four tests added (zero-weight votes ignored by both statistics; a zero-weight vote cannot move a boundary tie; negative weights still fail closed; an all-zero ballot still refuses).
- `ruff check src tests`: clean.
- `./reproduce h100 2026-09-02` and `./reproduce h200 2026-09-02` against the public record: 96 MATCH, 0 MISMATCH each.
- DCO sign-off present.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getcomputable/codesmith/gpu-index/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791061032&installation_model_id=433894&pr_number=45&repository=getcomputable%2Fgpu-index&return_to=https%3A%2F%2Fgithub.com%2Fgetcomputable%2Fgpu-index%2Fpull%2F45&signature=af0457b181d59491cee94e18c73ac17746620c2240310138aa1b52738b648d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->