### PR TITLE
fix(reproduce): full re-derivation summary carries the degraded count

### DIFF
--- a/scripts/verify_published_record.py
+++ b/scripts/verify_published_record.py
@@ -178,9 +178,11 @@ def _run_full(reader, *, sku: str, date: str, stamp: str | None) -> int:
                 f"{divergence.quantity} derived {divergence.derived!r} "
                 f"published {divergence.published!r}"
             )
+    # Same summary shape as the receipts path below: the full re-derivation
+    # has no digest-only verdict, so its degraded count is always 0.
     print(
         f"summary: {len(checks)} observation(s): {matched} MATCH, "
-        f"{mismatched} MISMATCH"
+        f"{mismatched} MISMATCH, 0 degraded"
     )
     return 1 if mismatched else 0
 


### PR DESCRIPTION
## Summary

The full-replay path of `scripts/verify_published_record.py` printed `summary: N observation(s): N MATCH, N MISMATCH` while the receipts path prints `…, N degraded`. The scheduled live-record job parses the four-field shape, so every `./reproduce <sku> <date>` it launched exited 0 and then failed with `summary is None`. The full path has no digest-only verdict, so its degraded count is always 0; it now prints it, and both paths share one summary shape.

## Verification

- `pytest -m live tests/live/test_published_front_live.py -k "h100 or b300"` against the public record: 2 passed (both failed on main).
- Unit suite green; the existing `"1 MATCH, 0 MISMATCH"` substring assertions still hold.
- DCO sign-off present.

The remaining live-record failures (`test_published_weights_re_derive_from_the_published_inputs` on H100/H200/B200 and `test_an_excluded_seat_carries_no_weight_and_no_price[H100]`) are a separate engine-mirror gap and are tracked separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getcomputable/codesmith/gpu-index/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791061830&installation_model_id=433894&pr_number=46&repository=getcomputable%2Fgpu-index&return_to=https%3A%2F%2Fgithub.com%2Fgetcomputable%2Fgpu-index%2Fpull%2F46&signature=1117c5069af2abc465117c491f445a344cc0cea97f1930a335f94d8e8a197f47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->