### PR TITLE
fix(verify): latest.json may carry the publisher's activation bundle

### DIFF
--- a/src/gpu_index/published/artifacts.py
+++ b/src/gpu_index/published/artifacts.py
@@ -454,14 +454,25 @@ def _validate_data(data: Any) -> List[Any]:
         raise PublishedRecordError("envelope data must be an object")
     kind = data.get("kind")
     if kind == "gpu_index_latest":
+        # ``activation`` is the publisher's replay-from-anchor bundle (the
+        # activation ledger's hash chain, checkpoints and projections). The
+        # reader contract admits it present, absent, or null; this verifier
+        # recomputes values from receipts and calc_params and does not
+        # consume the bundle, so it is admitted as an opaque object and
+        # nothing inside it is interpreted here.
         _require_keys(
             data,
             frozenset({"kind", "observations"}),
             "latest data",
-            frozenset({"versions"}),
+            frozenset({"versions", "activation"}),
         )
         if "versions" in data:
             _validate_versions(data["versions"])
+        if "activation" in data and data["activation"] is not None:
+            if not isinstance(data["activation"], dict):
+                raise PublishedRecordError(
+                    "latest data.activation must be an object or null"
+                )
     elif kind == "gpu_index_observation_day":
         _require_keys(
             data, frozenset({"kind", "date", "observations"}), "day data"

--- a/tests/unit/test_published_verify.py
+++ b/tests/unit/test_published_verify.py
@@ -174,6 +174,50 @@ def test_latest_pointer_observations_match_too():
     assert all(c.verdict == VERDICT_MATCH for c in checks)
 
 
+def test_latest_pointer_admits_the_activation_bundle():
+    """The publisher's replay-from-anchor bundle rides ``latest.json`` as
+    ``data.activation``; the reader contract admits it present, absent, or
+    null. The verifier recomputes values from receipts and does not read
+    the bundle, so it is admitted as an opaque object: the pointer that
+    went live on 2026-09-03 must still verify and reproduce."""
+    def with_bundle(document):
+        document["data"]["activation"] = {
+            "schema_version": "1",
+            "anchor": {"sequence": 3, "record_sha256": "a" * 64},
+            "current": {"sequence": 6, "record_sha256": "b" * 64},
+            "chain": [],
+            "checkpoints": [],
+            "projections": [],
+            "changelog_tail": [],
+        }
+
+    def with_null(document):
+        document["data"]["activation"] = None
+
+    for mutate in (with_bundle, with_null):
+        envelope = _tampered("latest.json", mutate)
+        checks = [
+            recompute_observation(obs)
+            for obs in select_observations(envelope)
+        ]
+        assert all(c.verdict == VERDICT_MATCH for c in checks)
+
+
+def test_latest_pointer_refuses_a_malformed_bundle_and_unknown_keys():
+    """Admitting one named key does not open the contract: a non-object
+    bundle and any other unexpected key still refuse."""
+    def bad_bundle(document):
+        document["data"]["activation"] = "not-a-bundle"
+
+    def unknown_key(document):
+        document["data"]["extra"] = {}
+
+    with pytest.raises(PublishedRecordError, match="activation"):
+        _tampered("latest.json", bad_bundle)
+    with pytest.raises(PublishedRecordError, match="unexpected"):
+        _tampered("latest.json", unknown_key)
+
+
 # ------------------------------------------------------------------- tampers
 
 


### PR DESCRIPTION
## Summary

The publisher now writes its replay-from-anchor bundle into `latest.json` as `data.activation`. This verifier required an exact key set on the latest data block, so every `./reproduce` run refused the live pointer with `unexpected ['activation']` once the new publisher went live on 2026-09-03.

The reader contract admits the bundle present, absent, or null. This verifier recomputes values from receipts and `calc_params` and does not consume the bundle, so it is admitted as an opaque object and nothing inside it is interpreted. A non-object bundle and any other unexpected key still refuse (tested).

## Verification

- `./reproduce h100 2026-09-02`, `h200`, `b300`, `b200` from a clean checkout with its own venv against the public record: 96 MATCH, 0 MISMATCH, 0 degraded each. All four refused before this change.
- Unit suite green (two tests added); `ruff check` clean; DCO sign-off present.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getcomputable/codesmith/gpu-index/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791065155&installation_model_id=433894&pr_number=48&repository=getcomputable%2Fgpu-index&return_to=https%3A%2F%2Fgithub.com%2Fgetcomputable%2Fgpu-index%2Fpull%2F48&signature=30e31cd71d3bb0c138f9e6705311188c7c4a8487cec9d6a140d967d838a290fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->